### PR TITLE
Story#109965360 - do not validate destroyed domain nameservers

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -543,7 +543,7 @@ class Domain < ActiveRecord::Base
   ### VALIDATIONS ###
 
   def validate_nameserver_ips
-    nameservers.each do |ns|
+    nameservers.to_a.reject(&:marked_for_destruction?).each do |ns|
       next unless ns.hostname.end_with?(name)
       next if ns.ipv4.present?
       errors.add(:nameservers, :invalid) if errors[:nameservers].blank?


### PR DESCRIPTION
domain was locked for update if glue IP was missing