### PR TITLE
Add puma gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,6 +115,7 @@ group :development do
 
   # deploy
   gem 'mina', '0.3.1' # for fast deployment
+  gem 'puma'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -362,6 +362,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    puma (3.8.2)
     que (0.10.0)
     que-web (0.4.0)
       erubis
@@ -627,6 +628,7 @@ DEPENDENCIES
   phantomjs-binaries (= 1.9.2.4)
   poltergeist (= 1.6.0)
   pry (= 0.10.1)
+  puma
   que (= 0.10.0)
   que-web (= 0.4.0)
   que_mailer!


### PR DESCRIPTION
- This gem is needed for development as a replacement of default single-threaded webrick
- Unfortunately, it requires to be added to Gemfile
- It is a new default for Rails 5