### PR TITLE
Do not load FactoryGirl factories in dev.rake

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -7,7 +7,6 @@ namespace :dev do
 
     require 'factory_girl'
     include FactoryGirl::Syntax::Methods
-    FactoryGirl.find_definitions
 
     PaperTrail.enabled = false
     Domain.paper_trail_on!


### PR DESCRIPTION
FactoryGirl is now under "development" group in Gemfile too. No production code changed. Nothing to test.