### PR TITLE
Update Devise to latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'liquid',           '3.0.6'   # for email templates
 
 # rights
 gem 'cancancan', '1.11.0' # autharization
-gem 'devise',    '3.5.4'  # authenitcation
+gem 'devise',    '4.4.3'  # authenitcation
 
 # rest api
 gem 'grape',    '0.12.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,12 +167,11 @@ GEM
     database_cleaner (1.6.1)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    devise (3.5.4)
+    devise (4.4.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 3.2.6, < 5)
+      railties (>= 4.1.0, < 6.0)
       responders
-      thread_safe (~> 0.1)
       warden (~> 1.2.3)
     diff-lcs (1.3)
     docile (1.1.5)
@@ -350,8 +349,9 @@ GEM
       polyamorous (~> 1.1)
     rdoc (4.3.0)
     request_store (1.1.0)
-    responders (2.3.0)
-      railties (>= 4.2.0, < 5.1)
+    responders (2.4.0)
+      actionpack (>= 4.2.0, < 5.3)
+      railties (>= 4.2.0, < 5.3)
     rest-client (2.0.1)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -491,7 +491,7 @@ DEPENDENCIES
   daemons-rails (= 1.2.1)
   data_migrate!
   database_cleaner
-  devise (= 3.5.4)
+  devise (= 4.4.3)
   digidoc_client!
   epp (= 1.5.0)!
   epp-xml (= 1.1.0)!


### PR DESCRIPTION
Prerequsite for Ruby upgrade to 2.5. Also enables future upgrade to
Rails 5 or above.