### PR TITLE
Add UUID db columns

### DIFF
--- a/app/models/concerns/contact/transferable.rb
+++ b/app/models/concerns/contact/transferable.rb
@@ -16,6 +16,7 @@ module Concerns::Contact::Transferable
     new_contact.regenerate_code
     new_contact.regenerate_auth_info
     new_contact.remove_address unless self.class.address_processing?
+    new_contact.uuid = nil
     new_contact.save(validate: false)
     new_contact
   end

--- a/db/migrate/20180612042234_enable_pgcrypto_ext.rb
+++ b/db/migrate/20180612042234_enable_pgcrypto_ext.rb
@@ -1,0 +1,5 @@
+class EnablePgcryptoExt < ActiveRecord::Migration
+  def change
+    enable_extension 'pgcrypto'
+  end
+end

--- a/db/migrate/20180612042625_add_uuid_to_contacts.rb
+++ b/db/migrate/20180612042625_add_uuid_to_contacts.rb
@@ -1,0 +1,5 @@
+class AddUuidToContacts < ActiveRecord::Migration
+  def change
+    add_column :contacts, :uuid, :uuid, default: 'gen_random_uuid()'
+  end
+end

--- a/db/migrate/20180612042953_add_uuid_to_domains.rb
+++ b/db/migrate/20180612042953_add_uuid_to_domains.rb
@@ -1,0 +1,5 @@
+class AddUuidToDomains < ActiveRecord::Migration
+  def change
+    add_column :domains, :uuid, :uuid, default: 'gen_random_uuid()'
+  end
+end

--- a/db/migrate/20180613030330_change_contacts_and_domains_uuid_to_not_null.rb
+++ b/db/migrate/20180613030330_change_contacts_and_domains_uuid_to_not_null.rb
@@ -1,0 +1,6 @@
+class ChangeContactsAndDomainsUuidToNotNull < ActiveRecord::Migration
+  def change
+    change_column_null :contacts, :uuid, false
+    change_column_null :domains, :uuid, false
+  end
+end

--- a/db/migrate/20180613045614_add_contacts_and_domains_uuid_uniq_constraint.rb
+++ b/db/migrate/20180613045614_add_contacts_and_domains_uuid_uniq_constraint.rb
@@ -1,0 +1,15 @@
+class AddContactsAndDomainsUuidUniqConstraint < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      ALTER TABLE contacts ADD CONSTRAINT uniq_contact_uuid UNIQUE (uuid);
+      ALTER TABLE domains ADD CONSTRAINT uniq_domain_uuid UNIQUE (uuid);
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TABLE contacts DROP CONSTRAINT uniq_contact_uuid;
+      ALTER TABLE domains DROP CONSTRAINT uniq_domain_uuid;
+    SQL
+  end
+end

--- a/db/migrate/20180613045614_add_contacts_and_domains_uuid_uniq_constraint.rb
+++ b/db/migrate/20180613045614_add_contacts_and_domains_uuid_uniq_constraint.rb
@@ -1,3 +1,4 @@
+# Unique constraint is needed to prevent accidental duplicate values in fixtures to appear in DB
 class AddContactsAndDomainsUuidUniqConstraint < ActiveRecord::Migration
   def up
     execute <<-SQL

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -912,7 +912,8 @@ CREATE TABLE domains (
     status_notes hstore,
     statuses_backup character varying[] DEFAULT '{}'::character varying[],
     upid integer,
-    up_date timestamp without time zone
+    up_date timestamp without time zone,
+    uuid uuid DEFAULT gen_random_uuid()
 );
 
 
@@ -4734,4 +4735,6 @@ INSERT INTO schema_migrations (version) VALUES ('20180331200125');
 INSERT INTO schema_migrations (version) VALUES ('20180612042234');
 
 INSERT INTO schema_migrations (version) VALUES ('20180612042625');
+
+INSERT INTO schema_migrations (version) VALUES ('20180612042953');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -640,7 +640,7 @@ CREATE TABLE contacts (
     ident_updated_at timestamp without time zone,
     upid integer,
     up_date timestamp without time zone,
-    uuid uuid DEFAULT gen_random_uuid()
+    uuid uuid DEFAULT gen_random_uuid() NOT NULL
 );
 
 
@@ -913,7 +913,7 @@ CREATE TABLE domains (
     statuses_backup character varying[] DEFAULT '{}'::character varying[],
     upid integer,
     up_date timestamp without time zone,
-    uuid uuid DEFAULT gen_random_uuid()
+    uuid uuid DEFAULT gen_random_uuid() NOT NULL
 );
 
 
@@ -4737,4 +4737,6 @@ INSERT INTO schema_migrations (version) VALUES ('20180612042234');
 INSERT INTO schema_migrations (version) VALUES ('20180612042625');
 
 INSERT INTO schema_migrations (version) VALUES ('20180612042953');
+
+INSERT INTO schema_migrations (version) VALUES ('20180613030330');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -51,6 +51,20 @@ CREATE EXTENSION IF NOT EXISTS hstore WITH SCHEMA public;
 COMMENT ON EXTENSION hstore IS 'data type for storing sets of (key, value) pairs';
 
 
+--
+-- Name: pgcrypto; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION pgcrypto; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
+
+
 SET search_path = public, pg_catalog;
 
 --
@@ -4715,4 +4729,6 @@ INSERT INTO schema_migrations (version) VALUES ('20180314122722');
 INSERT INTO schema_migrations (version) VALUES ('20180327151906');
 
 INSERT INTO schema_migrations (version) VALUES ('20180331200125');
+
+INSERT INTO schema_migrations (version) VALUES ('20180612042234');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3259,6 +3259,22 @@ ALTER TABLE ONLY settings
 
 
 --
+-- Name: uniq_contact_uuid; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY contacts
+    ADD CONSTRAINT uniq_contact_uuid UNIQUE (uuid);
+
+
+--
+-- Name: uniq_domain_uuid; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY domains
+    ADD CONSTRAINT uniq_domain_uuid UNIQUE (uuid);
+
+
+--
 -- Name: unique_code; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -4739,4 +4755,6 @@ INSERT INTO schema_migrations (version) VALUES ('20180612042625');
 INSERT INTO schema_migrations (version) VALUES ('20180612042953');
 
 INSERT INTO schema_migrations (version) VALUES ('20180613030330');
+
+INSERT INTO schema_migrations (version) VALUES ('20180613045614');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -639,7 +639,8 @@ CREATE TABLE contacts (
     original_id integer,
     ident_updated_at timestamp without time zone,
     upid integer,
-    up_date timestamp without time zone
+    up_date timestamp without time zone,
+    uuid uuid DEFAULT gen_random_uuid()
 );
 
 
@@ -4731,4 +4732,6 @@ INSERT INTO schema_migrations (version) VALUES ('20180327151906');
 INSERT INTO schema_migrations (version) VALUES ('20180331200125');
 
 INSERT INTO schema_migrations (version) VALUES ('20180612042234');
+
+INSERT INTO schema_migrations (version) VALUES ('20180612042625');
 

--- a/test/fixtures/contacts.yml
+++ b/test/fixtures/contacts.yml
@@ -8,6 +8,7 @@ john:
   registrar: bestnames
   code: john-001
   auth_info: cacb5b
+  uuid: eb2f2766-b44c-4e14-9f16-32ab1a7cb957
 
 william: &william
   name: William
@@ -27,6 +28,7 @@ william: &william
   country_code: US
   statuses:
     - ok
+  uuid: 0aa54704-d6f7-4ca9-b8ca-2827d9a4e4eb
 
 jane:
   name: Jane
@@ -38,6 +40,7 @@ jane:
   registrar: bestnames
   code: jane-001
   auth_info: 0aa09f
+  uuid: 9db3de62-2414-4487-bee2-d5c155567768
 
 acme_ltd:
   name: Acme Ltd
@@ -49,6 +52,7 @@ acme_ltd:
   ident_country_code: US
   code: acme-ltd-001
   auth_info: 720b3c
+  uuid: f1dd365c-5be9-4b3d-a44e-3fa002465e4d
 
 jack:
   name: Jack
@@ -60,12 +64,14 @@ jack:
   ident_country_code: US
   code: jack-001
   auth_info: e2c440
+  uuid: 28b65455-6f1a-49fd-961c-0758886dbd75
 
 identical_to_william:
   <<: *william
   registrar: goodnames
   code: william-002
   auth_info: 5ab865
+  uuid: c0a191d5-3793-4f0b-8f85-491612d0293e
 
 not_in_use:
   name: Useless
@@ -73,6 +79,7 @@ not_in_use:
   registrar: bestnames
   code: useless-001
   auth_info: e75a2a
+  uuid: ca613cc5-a8dc-48c1-8d32-d3c6a0b6c952
 
 invalid:
   name: any
@@ -80,3 +87,4 @@ invalid:
   email: invalid@invalid.test
   auth_info: any
   registrar: bestnames
+  uuid: bd80c0f9-26ee-49e0-a2cb-2311d931c433

--- a/test/fixtures/domains.yml
+++ b/test/fixtures/domains.yml
@@ -7,6 +7,7 @@ shop:
   valid_to: 2010-07-05
   period: 1
   period_unit: m
+  uuid: 1b3ee442-e8fe-4922-9492-8fcb9dccc69c
 
 airport:
   name: airport.test
@@ -17,6 +18,7 @@ airport:
   valid_to: 2010-07-05
   period: 1
   period_unit: m
+  uuid: 2df2c1a1-8f6a-490a-81be-8bdf29866880
 
 library:
   name: library.test
@@ -27,6 +29,7 @@ library:
   valid_to: 2010-07-05
   period: 1
   period_unit: m
+  uuid: 647bcc48-8d5e-4a04-8ce5-2a3cd17b6eab
 
 metro:
   name: metro.test
@@ -37,6 +40,7 @@ metro:
   valid_to: 2010-07-05
   period: 1
   period_unit: m
+  uuid: ef97cb80-333b-4893-b9df-163f2b452798
 
 invalid:
   name: invalid.test
@@ -44,3 +48,4 @@ invalid:
   valid_to: <%= Time.zone.parse('2010-07-05').utc.to_s(:db) %>
   registrar: bestnames
   registrant: invalid
+  uuid: 3c430ead-bb17-4b5b-aaa1-caa7dde7e138


### PR DESCRIPTION
- Needed for REST API v2 (#849)
- Test domain/contact adding/editing, contact/domain transfer
- REST API v1 will probably start returning UUIDs as well, since there is no filter on API side (it just returns all values straight from a DB). Don't think it might be a problem