### PR TITLE
Get rid of CVE-2018-3769 by updating Grape

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,7 +186,7 @@ GEM
       thor (~> 0.14)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    grape (1.0.3)
+    grape (1.1.0)
       activesupport
       builder
       mustermann-grape (~> 1.0.0)


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2018-3769