### PR TITLE
Quote value in fixture

### DIFF
--- a/test/fixtures/contacts.yml
+++ b/test/fixtures/contacts.yml
@@ -14,7 +14,7 @@ william: &william
   name: William
   email: william@inbox.test
   phone: '+555.555'
-  fax: +555.555
+  fax: '+666.6'
   ident: 1234
   ident_type: priv
   ident_country_code: US


### PR DESCRIPTION
Nothing to test.

- Quite nasty bug when the text value is interpreted as float
- New value so that phone and fax values would be different
- Fax testing will be done in #753
