### PR TITLE
Update CodeClimate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -19,6 +19,7 @@ plugins:
     enabled: true
   rubocop:
     enabled: true
+    channel: rubocop-0-58
 exclude_patterns:
   - "bin/"
   - "config/"


### PR DESCRIPTION
Update Rubocop version. It seems our config https://github.com/internetee/style-guide/blob/master/ruby/.rubocop.yml is currently ignored. This PR fixes this.