### PR TITLE
Make whois JSON test order independent

### DIFF
--- a/test/models/whois_record_test.rb
+++ b/test/models/whois_record_test.rb
@@ -22,13 +22,16 @@ class WhoisRecordTest < ActiveSupport::TestCase
       registrant_kind: 'priv',
       email: 'john@inbox.test',
       expire: '2010-07-05',
-      nameservers: ['ns1.bestnames.test', 'ns2.bestnames.test'],
       registrar_address: 'Main Street, New York, New York, 12345',
       dnssec_keys: [],
     }
 
     expected_partial_hash.each do |key, value|
       assert_equal(value, @record.generated_json[key])
+    end
+
+    ['ns1.bestnames.test', 'ns2.bestnames.test'].each do |item|
+      assert(@record.generated_json[:nameservers].include?(item))
     end
   end
 


### PR DESCRIPTION
The test relied on nameservers being inserted in specific order. For
whatever reason, that order can change, but it does not make the
record invalid.

`[ns1.google.com, ns2.google.com]` is semantically equal to
`[ns2.google.com, ns1.google.com]`