### PR TITLE
Fix a regression, where `user_session_timeout` setting in `application.yml` is not respected.

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -173,7 +173,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = ENV['user_session_timeout'].to_i.seconds if ENV['user_session_timeout']
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
Introduced in ebe831e78247bde3eb50347969b46622ee24db21