### PR TITLE
Return version logging to `prices` DB table

### DIFF
--- a/app/models/billing/price.rb
+++ b/app/models/billing/price.rb
@@ -1,6 +1,7 @@
 module Billing
   class Price < ApplicationRecord
     include Concerns::Billing::Price::Expirable
+    include Versions
 
     belongs_to :zone, class_name: 'DNS::Zone', required: true
     has_many :account_activities

--- a/app/models/version/billing/price_version.rb
+++ b/app/models/version/billing/price_version.rb
@@ -1,0 +1,7 @@
+module Billing
+  class PriceVersion < PaperTrail::Version
+    self.table_name    = :log_prices
+    self.sequence_name = :log_prices_id_seq
+  end
+end
+

--- a/db/migrate/20180916133911_remove_paper_trail_columns_from_prices.rb
+++ b/db/migrate/20180916133911_remove_paper_trail_columns_from_prices.rb
@@ -1,6 +1,0 @@
-class RemovePaperTrailColumnsFromPrices < ActiveRecord::Migration
-  def change
-    remove_column :prices, :creator_str
-    remove_column :prices, :updator_str
-  end
-end

--- a/db/migrate/20180916133911_remove_paper_trail_columns_from_prices.rb
+++ b/db/migrate/20180916133911_remove_paper_trail_columns_from_prices.rb
@@ -1,0 +1,6 @@
+class RemovePaperTrailColumnsFromPrices < ActiveRecord::Migration
+  def change
+    remove_column :prices, :creator_str
+    remove_column :prices, :updator_str
+  end
+end

--- a/db/migrate/20200910102028_create_version_for_prices.rb
+++ b/db/migrate/20200910102028_create_version_for_prices.rb
@@ -1,0 +1,26 @@
+class CreateVersionForPrices < ActiveRecord::Migration[6.0]
+  def up
+    create_table :log_prices, force: :cascade do |t|
+      t.string :item_type, null: false
+      t.integer :item_id, null: false
+      t.string :event, null: false
+      t.string :whodunnit
+      t.json :object
+      t.json :object_changes
+      t.datetime :created_at
+      t.string :session
+      t.json :children
+      t.string :uuid
+    end
+
+    add_index 'log_prices', ['item_type', 'item_id'], name: 'index_log_prices_on_item_type_and_item_id', using: :btree
+    add_index 'log_prices', ['whodunnit'], name: 'index_log_prices_on_whodunnit', using: :btree
+  end
+
+  def down
+    remove_index :log_prices, name: 'index_log_prices_on_item_type_and_item_id'
+    remove_index :log_prices, name: 'index_log_prices_on_whodunnit'
+
+    drop_table :log_prices
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2092,8 +2092,6 @@ CREATE TABLE public.prices (
     price_cents integer NOT NULL,
     valid_from timestamp without time zone,
     valid_to timestamp without time zone,
-    creator_str character varying,
-    updator_str character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     duration interval,
@@ -4853,4 +4851,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200908131554'),
 ('20200910085157');
 
+
+INSERT INTO schema_migrations (version) VALUES ('20180916133911');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -371,7 +371,6 @@ CREATE TABLE public.bank_statements (
     id integer NOT NULL,
     bank_code character varying,
     iban character varying,
-    import_file_path character varying,
     queried_at timestamp without time zone,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
@@ -778,7 +777,6 @@ CREATE TABLE public.domains (
     id integer NOT NULL,
     name character varying NOT NULL,
     registrar_id integer NOT NULL,
-    registered_at timestamp without time zone,
     valid_to timestamp without time zone NOT NULL,
     registrant_id integer NOT NULL,
     transfer_code character varying NOT NULL,
@@ -2124,7 +2122,7 @@ ALTER SEQUENCE public.payment_orders_id_seq OWNED BY public.payment_orders.id;
 
 
 --
--- Name: prices; Type: TABLE; Schema: public; Owner: -
+-- Name: prices; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE public.prices (
@@ -2132,13 +2130,13 @@ CREATE TABLE public.prices (
     price_cents integer NOT NULL,
     valid_from timestamp without time zone,
     valid_to timestamp without time zone,
+    updator_str character varying,
+    creator_str character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     duration interval,
     operation_category character varying,
-    zone_id integer NOT NULL,
-    updator_str character varying,
-    creator_str character varying
+    zone_id integer NOT NULL
 );
 
 
@@ -2878,7 +2876,14 @@ ALTER TABLE ONLY public.log_payment_orders ALTER COLUMN id SET DEFAULT nextval('
 
 
 --
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: log_prices id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.log_prices ALTER COLUMN id SET DEFAULT nextval('public.log_prices_id_seq'::regclass);
+
+
+--
+-- Name: log_registrant_verifications id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.log_registrant_verifications ALTER COLUMN id SET DEFAULT nextval('public.log_registrant_verifications_id_seq'::regclass);
@@ -3360,7 +3365,7 @@ ALTER TABLE ONLY public.log_registrant_verifications
 
 
 --
--- Name: log_registrars log_registrars_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: log_registrars_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY public.log_registrars
@@ -4801,7 +4806,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180825193437'),
 ('20180825232819'),
 ('20180826162821'),
-('20180916133911'),
 ('20181001090536'),
 ('20181002090319'),
 ('20181017092829'),
@@ -4875,6 +4879,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191203083643'),
 ('20191206183853'),
 ('20191212133136'),
+('20191217013225'),
 ('20191219112434'),
 ('20191219124429'),
 ('20191227110904'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -371,6 +371,7 @@ CREATE TABLE public.bank_statements (
     id integer NOT NULL,
     bank_code character varying,
     iban character varying,
+    import_file_path character varying,
     queried_at timestamp without time zone,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
@@ -777,6 +778,7 @@ CREATE TABLE public.domains (
     id integer NOT NULL,
     name character varying NOT NULL,
     registrar_id integer NOT NULL,
+    registered_at timestamp without time zone,
     valid_to timestamp without time zone NOT NULL,
     registrant_id integer NOT NULL,
     transfer_code character varying NOT NULL,
@@ -1706,7 +1708,45 @@ ALTER SEQUENCE public.log_payment_orders_id_seq OWNED BY public.log_payment_orde
 
 
 --
--- Name: log_registrant_verifications; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: log_prices; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.log_prices (
+    id bigint NOT NULL,
+    item_type character varying NOT NULL,
+    item_id integer NOT NULL,
+    event character varying NOT NULL,
+    whodunnit character varying,
+    object json,
+    object_changes json,
+    created_at timestamp without time zone,
+    session character varying,
+    children json,
+    uuid character varying
+);
+
+
+--
+-- Name: log_prices_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.log_prices_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: log_prices_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.log_prices_id_seq OWNED BY public.log_prices.id;
+
+
+--
+-- Name: log_registrant_verifications; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.log_registrant_verifications (
@@ -2084,7 +2124,7 @@ ALTER SEQUENCE public.payment_orders_id_seq OWNED BY public.payment_orders.id;
 
 
 --
--- Name: prices; Type: TABLE; Schema: public; Owner: -; Tablespace:
+-- Name: prices; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.prices (
@@ -2096,7 +2136,9 @@ CREATE TABLE public.prices (
     updated_at timestamp without time zone NOT NULL,
     duration interval,
     operation_category character varying,
-    zone_id integer NOT NULL
+    zone_id integer NOT NULL,
+    updator_str character varying,
+    creator_str character varying
 );
 
 
@@ -3302,7 +3344,15 @@ ALTER TABLE ONLY public.log_payment_orders
 
 
 --
--- Name: log_registrant_verifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: log_prices log_prices_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.log_prices
+    ADD CONSTRAINT log_prices_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: log_registrant_verifications log_registrant_verifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.log_registrant_verifications
@@ -3310,7 +3360,7 @@ ALTER TABLE ONLY public.log_registrant_verifications
 
 
 --
--- Name: log_registrars_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+-- Name: log_registrars log_registrars_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.log_registrars
@@ -4751,6 +4801,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180825193437'),
 ('20180825232819'),
 ('20180826162821'),
+('20180916133911'),
 ('20181001090536'),
 ('20181002090319'),
 ('20181017092829'),
@@ -4824,7 +4875,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191203083643'),
 ('20191206183853'),
 ('20191212133136'),
-('20191217013225'),
 ('20191219112434'),
 ('20191219124429'),
 ('20191227110904'),
@@ -4849,8 +4899,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200812090409'),
 ('20200812125810'),
 ('20200908131554'),
-('20200910085157');
-
-
-INSERT INTO schema_migrations (version) VALUES ('20180916133911');
+('20200910085157'),
+('20200910102028');
 


### PR DESCRIPTION
PaperTrail's `Version` model itself has been removed in #475, so those
columns are now useless