### PR TITLE
Remove PaperTrail from historical data models

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,6 +1,4 @@
 class Account < ActiveRecord::Base
-  include Versions
-
   belongs_to :registrar, required: true
   has_many :account_activities
 

--- a/app/models/account_activity.rb
+++ b/app/models/account_activity.rb
@@ -1,7 +1,6 @@
 require 'csv'
 
 class AccountActivity < ActiveRecord::Base
-  include Versions
   belongs_to :account, required: true
   belongs_to :bank_transaction
   belongs_to :invoice

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,5 +1,4 @@
 class Invoice < ActiveRecord::Base
-  include Versions
   belongs_to :seller, class_name: 'Registrar'
   belongs_to :buyer, class_name: 'Registrar'
   has_one  :account_activity

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -1,5 +1,4 @@
 class InvoiceItem < ActiveRecord::Base
-  include Versions
   belongs_to :invoice
 
   def item_sum_without_vat

--- a/app/models/version/account_activity_version.rb
+++ b/app/models/version/account_activity_version.rb
@@ -1,4 +1,0 @@
-class AccountActivityVersion < PaperTrail::Version
-  self.table_name    = :log_account_activities
-  self.sequence_name = :log_account_activities_id_seq
-end

--- a/app/models/version/account_version.rb
+++ b/app/models/version/account_version.rb
@@ -1,4 +1,0 @@
-class AccountVersion < PaperTrail::Version
-  self.table_name    = :log_accounts
-  self.sequence_name = :log_accounts_id_seq
-end

--- a/app/models/version/invoice_item_version.rb
+++ b/app/models/version/invoice_item_version.rb
@@ -1,4 +1,0 @@
-class InvoiceItemVersion < PaperTrail::Version
-  self.table_name    = :log_invoice_items
-  self.sequence_name = :log_invoice_items_id_seq
-end

--- a/app/models/version/invoice_version.rb
+++ b/app/models/version/invoice_version.rb
@@ -1,4 +1,0 @@
-class InvoiceVersion < PaperTrail::Version
-  self.table_name    = :log_invoices
-  self.sequence_name = :log_invoices_id_seq
-end

--- a/db/migrate/20180915211729_drop_log_account_activities.rb
+++ b/db/migrate/20180915211729_drop_log_account_activities.rb
@@ -1,0 +1,5 @@
+class DropLogAccountActivities < ActiveRecord::Migration
+  def change
+    drop_table :log_account_activities
+  end
+end

--- a/db/migrate/20180916120528_remove_paper_trail_columns_from_account_activities.rb
+++ b/db/migrate/20180916120528_remove_paper_trail_columns_from_account_activities.rb
@@ -1,0 +1,6 @@
+class RemovePaperTrailColumnsFromAccountActivities < ActiveRecord::Migration
+  def change
+    remove_column :account_activities, :creator_str
+    remove_column :account_activities, :updator_str
+  end
+end

--- a/db/migrate/20180916122359_drop_log_accounts.rb
+++ b/db/migrate/20180916122359_drop_log_accounts.rb
@@ -1,0 +1,5 @@
+class DropLogAccounts < ActiveRecord::Migration
+  def change
+    drop_table :log_accounts
+  end
+end

--- a/db/migrate/20180916122456_remove_paper_trail_columns_from_accounts.rb
+++ b/db/migrate/20180916122456_remove_paper_trail_columns_from_accounts.rb
@@ -1,0 +1,6 @@
+class RemovePaperTrailColumnsFromAccounts < ActiveRecord::Migration
+  def change
+    remove_column :accounts, :creator_str
+    remove_column :accounts, :updator_str
+  end
+end

--- a/db/migrate/20180916122713_drop_log_invoices.rb
+++ b/db/migrate/20180916122713_drop_log_invoices.rb
@@ -1,0 +1,5 @@
+class DropLogInvoices < ActiveRecord::Migration
+  def change
+    drop_table :log_invoices
+  end
+end

--- a/db/migrate/20180916122843_remove_paper_trail_columns_from_invoices.rb
+++ b/db/migrate/20180916122843_remove_paper_trail_columns_from_invoices.rb
@@ -1,0 +1,6 @@
+class RemovePaperTrailColumnsFromInvoices < ActiveRecord::Migration
+  def change
+    remove_column :invoices, :creator_str
+    remove_column :invoices, :updator_str
+  end
+end

--- a/db/migrate/20180916123045_drop_log_invoice_items.rb
+++ b/db/migrate/20180916123045_drop_log_invoice_items.rb
@@ -1,0 +1,5 @@
+class DropLogInvoiceItems < ActiveRecord::Migration
+  def change
+    drop_table :log_invoice_items
+  end
+end

--- a/db/migrate/20180916123150_remove_paper_trail_columns_from_invoice_items.rb
+++ b/db/migrate/20180916123150_remove_paper_trail_columns_from_invoice_items.rb
@@ -1,0 +1,6 @@
+class RemovePaperTrailColumnsFromInvoiceItems < ActiveRecord::Migration
+  def change
+    remove_column :invoice_items, :creator_str
+    remove_column :invoice_items, :updator_str
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -308,8 +308,6 @@ CREATE TABLE public.account_activities (
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     description character varying,
-    creator_str character varying,
-    updator_str character varying,
     activity_type character varying,
     price_id integer
 );
@@ -345,9 +343,7 @@ CREATE TABLE public.accounts (
     balance numeric(10,2) DEFAULT 0.0 NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    currency character varying,
-    creator_str character varying,
-    updator_str character varying
+    currency character varying
 );
 
 
@@ -980,9 +976,7 @@ CREATE TABLE public.invoice_items (
     amount integer,
     price numeric(10,2),
     created_at timestamp without time zone,
-    updated_at timestamp without time zone,
-    creator_str character varying,
-    updator_str character varying
+    updated_at timestamp without time zone
 );
 
 
@@ -1047,8 +1041,6 @@ CREATE TABLE public.invoices (
     buyer_phone character varying,
     buyer_url character varying,
     buyer_email character varying,
-    creator_str character varying,
-    updator_str character varying,
     number integer,
     cancelled_at timestamp without time zone,
     total numeric(10,2) NOT NULL,
@@ -1152,82 +1144,6 @@ CREATE SEQUENCE public.legal_documents_id_seq
 --
 
 ALTER SEQUENCE public.legal_documents_id_seq OWNED BY public.legal_documents.id;
-
-
---
--- Name: log_account_activities; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE public.log_account_activities (
-    id integer NOT NULL,
-    item_type character varying NOT NULL,
-    item_id integer NOT NULL,
-    event character varying NOT NULL,
-    whodunnit character varying,
-    object json,
-    object_changes json,
-    created_at timestamp without time zone,
-    session character varying,
-    children json,
-    uuid character varying
-);
-
-
---
--- Name: log_account_activities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.log_account_activities_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: log_account_activities_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.log_account_activities_id_seq OWNED BY public.log_account_activities.id;
-
-
---
--- Name: log_accounts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE public.log_accounts (
-    id integer NOT NULL,
-    item_type character varying NOT NULL,
-    item_id integer NOT NULL,
-    event character varying NOT NULL,
-    whodunnit character varying,
-    object json,
-    object_changes json,
-    created_at timestamp without time zone,
-    session character varying,
-    children json,
-    uuid character varying
-);
-
-
---
--- Name: log_accounts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.log_accounts_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: log_accounts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.log_accounts_id_seq OWNED BY public.log_accounts.id;
 
 
 --
@@ -1536,82 +1452,6 @@ CREATE SEQUENCE public.log_domains_id_seq
 --
 
 ALTER SEQUENCE public.log_domains_id_seq OWNED BY public.log_domains.id;
-
-
---
--- Name: log_invoice_items; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE public.log_invoice_items (
-    id integer NOT NULL,
-    item_type character varying NOT NULL,
-    item_id integer NOT NULL,
-    event character varying NOT NULL,
-    whodunnit character varying,
-    object json,
-    object_changes json,
-    created_at timestamp without time zone,
-    session character varying,
-    children json,
-    uuid character varying
-);
-
-
---
--- Name: log_invoice_items_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.log_invoice_items_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: log_invoice_items_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.log_invoice_items_id_seq OWNED BY public.log_invoice_items.id;
-
-
---
--- Name: log_invoices; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE public.log_invoices (
-    id integer NOT NULL,
-    item_type character varying NOT NULL,
-    item_id integer NOT NULL,
-    event character varying NOT NULL,
-    whodunnit character varying,
-    object json,
-    object_changes json,
-    created_at timestamp without time zone,
-    session character varying,
-    children json,
-    uuid character varying
-);
-
-
---
--- Name: log_invoices_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.log_invoices_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: log_invoices_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.log_invoices_id_seq OWNED BY public.log_invoices.id;
 
 
 --
@@ -2624,20 +2464,6 @@ ALTER TABLE ONLY public.legal_documents ALTER COLUMN id SET DEFAULT nextval('pub
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.log_account_activities ALTER COLUMN id SET DEFAULT nextval('public.log_account_activities_id_seq'::regclass);
-
-
---
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.log_accounts ALTER COLUMN id SET DEFAULT nextval('public.log_accounts_id_seq'::regclass);
-
-
---
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
---
-
 ALTER TABLE ONLY public.log_bank_statements ALTER COLUMN id SET DEFAULT nextval('public.log_bank_statements_id_seq'::regclass);
 
 
@@ -2688,20 +2514,6 @@ ALTER TABLE ONLY public.log_domain_contacts ALTER COLUMN id SET DEFAULT nextval(
 --
 
 ALTER TABLE ONLY public.log_domains ALTER COLUMN id SET DEFAULT nextval('public.log_domains_id_seq'::regclass);
-
-
---
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.log_invoice_items ALTER COLUMN id SET DEFAULT nextval('public.log_invoice_items_id_seq'::regclass);
-
-
---
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.log_invoices ALTER COLUMN id SET DEFAULT nextval('public.log_invoices_id_seq'::regclass);
 
 
 --
@@ -3027,22 +2839,6 @@ ALTER TABLE ONLY public.legal_documents
 
 
 --
--- Name: log_account_activities_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
---
-
-ALTER TABLE ONLY public.log_account_activities
-    ADD CONSTRAINT log_account_activities_pkey PRIMARY KEY (id);
-
-
---
--- Name: log_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
---
-
-ALTER TABLE ONLY public.log_accounts
-    ADD CONSTRAINT log_accounts_pkey PRIMARY KEY (id);
-
-
---
 -- Name: log_bank_statements_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -3104,22 +2900,6 @@ ALTER TABLE ONLY public.log_domain_contacts
 
 ALTER TABLE ONLY public.log_domains
     ADD CONSTRAINT log_domains_pkey PRIMARY KEY (id);
-
-
---
--- Name: log_invoice_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
---
-
-ALTER TABLE ONLY public.log_invoice_items
-    ADD CONSTRAINT log_invoice_items_pkey PRIMARY KEY (id);
-
-
---
--- Name: log_invoices_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
---
-
-ALTER TABLE ONLY public.log_invoices
-    ADD CONSTRAINT log_invoices_pkey PRIMARY KEY (id);
 
 
 --
@@ -3608,34 +3388,6 @@ CREATE INDEX index_legal_documents_on_documentable_type_and_documentable_id ON p
 
 
 --
--- Name: index_log_account_activities_on_item_type_and_item_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_log_account_activities_on_item_type_and_item_id ON public.log_account_activities USING btree (item_type, item_id);
-
-
---
--- Name: index_log_account_activities_on_whodunnit; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_log_account_activities_on_whodunnit ON public.log_account_activities USING btree (whodunnit);
-
-
---
--- Name: index_log_accounts_on_item_type_and_item_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_log_accounts_on_item_type_and_item_id ON public.log_accounts USING btree (item_type, item_id);
-
-
---
--- Name: index_log_accounts_on_whodunnit; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_log_accounts_on_whodunnit ON public.log_accounts USING btree (whodunnit);
-
-
---
 -- Name: index_log_bank_statements_on_item_type_and_item_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -3745,34 +3497,6 @@ CREATE INDEX index_log_domains_on_item_type_and_item_id ON public.log_domains US
 --
 
 CREATE INDEX index_log_domains_on_whodunnit ON public.log_domains USING btree (whodunnit);
-
-
---
--- Name: index_log_invoice_items_on_item_type_and_item_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_log_invoice_items_on_item_type_and_item_id ON public.log_invoice_items USING btree (item_type, item_id);
-
-
---
--- Name: index_log_invoice_items_on_whodunnit; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_log_invoice_items_on_whodunnit ON public.log_invoice_items USING btree (whodunnit);
-
-
---
--- Name: index_log_invoices_on_item_type_and_item_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_log_invoices_on_item_type_and_item_id ON public.log_invoices USING btree (item_type, item_id);
-
-
---
--- Name: index_log_invoices_on_whodunnit; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_log_invoices_on_whodunnit ON public.log_invoices USING btree (whodunnit);
 
 
 --
@@ -4767,4 +4491,20 @@ INSERT INTO schema_migrations (version) VALUES ('20180808064402');
 INSERT INTO schema_migrations (version) VALUES ('20180816123540');
 
 INSERT INTO schema_migrations (version) VALUES ('20180824092855');
+
+INSERT INTO schema_migrations (version) VALUES ('20180915211729');
+
+INSERT INTO schema_migrations (version) VALUES ('20180916120528');
+
+INSERT INTO schema_migrations (version) VALUES ('20180916122359');
+
+INSERT INTO schema_migrations (version) VALUES ('20180916122456');
+
+INSERT INTO schema_migrations (version) VALUES ('20180916122713');
+
+INSERT INTO schema_migrations (version) VALUES ('20180916122843');
+
+INSERT INTO schema_migrations (version) VALUES ('20180916123045');
+
+INSERT INTO schema_migrations (version) VALUES ('20180916123150');
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -1,14 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Account do
-  it 'has versions' do
-    with_versioning do
-      price = build(:account)
-      price.save!
-      expect(price.versions.size).to be(1)
-    end
-  end
-
   describe 'registrar validation', db: false do
     subject(:account) { described_class.new }
 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -17,10 +17,6 @@ describe Invoice do
         "Seller name is missing",
       ])
     end
-
-    it 'should not have any versions' do
-      @invoice.versions.should == []
-    end
   end
 
   context 'with valid attributes' do
@@ -54,16 +50,6 @@ describe Invoice do
       create(:invoice, created_at: Time.zone.now - 35.days, due_date: Time.zone.now - 30.days)
       Invoice.cancel_overdue_invoices
       Invoice.where(cancelled_at: nil).count.should == 1
-    end
-
-    it 'should have one version' do
-      with_versioning do
-        @invoice.versions.should == []
-        @invoice.buyer_name = 'New name'
-        @invoice.save
-        @invoice.errors.full_messages.should match_array([])
-        @invoice.versions.size.should == 1
-      end
     end
   end
 end


### PR DESCRIPTION
Removes the following DB tables:
- `log_accounts`
- `log_account_activities`
- `log_invoices`
- `log_invoice_items`