### PR TITLE
Update nokogiri to 1.8.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,7 +267,7 @@ GEM
     mustermann-grape (1.0.0)
       mustermann (~> 1.0.0)
     netrc (0.11.0)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     nori (2.6.0)
     open4 (1.3.4)
@@ -508,4 +508,4 @@ DEPENDENCIES
   whenever (= 0.9.4)
 
 BUNDLED WITH
-   1.16.4
+   1.16.6


### PR DESCRIPTION
https://rubysec.com/advisories/nokogiri-CVE-2018-14404