### PR TITLE
Add handling of OPTIONS request to /api namespace

### DIFF
--- a/app/controllers/api/cors_controller.rb
+++ b/app/controllers/api/cors_controller.rb
@@ -1,0 +1,20 @@
+module Api
+  class CorsController < ApplicationController
+    skip_before_action :verify_authenticity_token
+    skip_authorization_check
+
+    def cors_preflight_check
+      set_access_control_headers
+      render json: { status: :ok }
+    end
+
+    def set_access_control_headers
+      response.headers['Access-Control-Allow-Origin'] = '*'
+      response.headers['Access-Control-Allow-Methods'] = 'POST, GET, PUT, PATCH, DELETE, OPTIONS'
+      response.headers['Access-Control-Allow-Headers'] = 'Origin, Content-Type, Accept, ' \
+                                                         'Authorization, Token, Auth-Token, '\
+                                                         'Email, X-User-Token, X-User-Email'
+      response.headers['Access-Control-Max-Age'] = '3600'
+    end
+  end
+end

--- a/app/controllers/api/cors_controller.rb
+++ b/app/controllers/api/cors_controller.rb
@@ -5,7 +5,7 @@ module Api
 
     def cors_preflight_check
       set_access_control_headers
-      render json: { status: :ok }
+      render text: ''
     end
 
     def set_access_control_headers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,9 @@ Rails.application.routes.draw do
         resources :contacts, only: %i[index show], param: :uuid
       end
     end
+
+    match '*all', controller: 'cors', action: 'cors_preflight_check', via: [:options],
+      as: 'cors_preflight_check'
   end
 
   # REGISTRAR ROUTES

--- a/test/integration/api/registrant/registrant_api_cors_headers_test.rb
+++ b/test/integration/api/registrant/registrant_api_cors_headers_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class RegistrantApiCorsHeadersTest < ApplicationIntegrationTest
+  def test_returns_200_response_code_for_options_request
+    options '/api/v1/registrant/auth/eid', {}
+
+    assert_equal('200', response.code)
+  end
+
+  def test_returns_expected_headers_for_options_requests
+    options '/api/v1/registrant/auth/eid', {}, { 'Origin' => 'https://example.com' }
+
+    assert_equal('*', response.headers['Access-Control-Allow-Origin'])
+    assert_equal('POST, GET, PUT, PATCH, DELETE, OPTIONS',
+                 response.headers['Access-Control-Allow-Methods'])
+    assert_equal('Origin, Content-Type, Accept, Authorization, Token, Auth-Token, Email, ' \
+                 'X-User-Token, X-User-Email',
+               response.headers['Access-Control-Allow-Headers'])
+    assert_equal('3600', response.headers['Access-Control-Max-Age'])
+  end
+end

--- a/test/integration/api/registrant/registrant_api_cors_headers_test.rb
+++ b/test/integration/api/registrant/registrant_api_cors_headers_test.rb
@@ -18,4 +18,10 @@ class RegistrantApiCorsHeadersTest < ApplicationIntegrationTest
                response.headers['Access-Control-Allow-Headers'])
     assert_equal('3600', response.headers['Access-Control-Max-Age'])
   end
+
+  def test_returns_empty_body
+    options '/api/v1/registrant/auth/eid', {}
+
+    assert_equal('', response.body)
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,6 +28,13 @@ class ActiveSupport::TestCase
   end
 end
 
+# Allows testing OPTIONS request just like GET or POST
+module ActionDispatch::Integration::RequestHelpers
+  def options(path, parameters = nil, headers_or_env = nil)
+    process :options, path, parameters, headers_or_env
+  end
+end
+
 class ApplicationIntegrationTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
   include Capybara::Minitest::Assertions


### PR DESCRIPTION
* It allows access from anywhere via wildcard origin
* It sets the timeout to an hour
* It allows all standard HTTP verbs + OPTIONS