### PR TITLE
Ensure cors headers are also returned for other requests

### DIFF
--- a/app/controllers/api/cors_controller.rb
+++ b/app/controllers/api/cors_controller.rb
@@ -9,7 +9,7 @@ module Api
     end
 
     def set_access_control_headers
-      response.headers['Access-Control-Allow-Origin'] = '*'
+      response.headers['Access-Control-Allow-Origin'] = request.headers['Origin']
       response.headers['Access-Control-Allow-Methods'] = 'POST, GET, PUT, PATCH, DELETE, OPTIONS'
       response.headers['Access-Control-Allow-Headers'] = 'Origin, Content-Type, Accept, ' \
                                                          'Authorization, Token, Auth-Token, '\

--- a/app/controllers/api/v1/registrant/auth_controller.rb
+++ b/app/controllers/api/v1/registrant/auth_controller.rb
@@ -29,7 +29,7 @@ module Api
         private
 
         def set_cors_header
-          response.headers['Access-Control-Allow-Origin'] = '*'
+          response.headers['Access-Control-Allow-Origin'] = request.headers['Origin']
         end
 
         def eid_params

--- a/app/controllers/api/v1/registrant/auth_controller.rb
+++ b/app/controllers/api/v1/registrant/auth_controller.rb
@@ -5,6 +5,7 @@ module Api
   module V1
     module Registrant
       class AuthController < ActionController::API
+        before_action :set_cors_header
         before_action :check_ip_whitelist
 
         rescue_from(ActionController::ParameterMissing) do |parameter_missing_exception|
@@ -26,6 +27,10 @@ module Api
         end
 
         private
+
+        def set_cors_header
+          response.headers['Access-Control-Allow-Origin'] = '*'
+        end
 
         def eid_params
           required_params = %i[ident first_name last_name]

--- a/app/controllers/api/v1/registrant/base_controller.rb
+++ b/app/controllers/api/v1/registrant/base_controller.rb
@@ -5,6 +5,7 @@ module Api
   module V1
     module Registrant
       class BaseController < ActionController::API
+        before_action :set_cors_header
         before_action :authenticate
         before_action :set_paper_trail_whodunnit
 
@@ -16,6 +17,10 @@ module Api
         end
 
         private
+
+        def set_cors_header
+          response.headers['Access-Control-Allow-Origin'] = '*'
+        end
 
         def bearer_token
           pattern = /^Bearer /

--- a/app/controllers/api/v1/registrant/base_controller.rb
+++ b/app/controllers/api/v1/registrant/base_controller.rb
@@ -19,7 +19,7 @@ module Api
         private
 
         def set_cors_header
-          response.headers['Access-Control-Allow-Origin'] = '*'
+          response.headers['Access-Control-Allow-Origin'] = request.headers['Origin']
         end
 
         def bearer_token

--- a/test/integration/api/registrant/registrant_api_cors_headers_test.rb
+++ b/test/integration/api/registrant/registrant_api_cors_headers_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class RegistrantApiCorsHeadersTest < ApplicationIntegrationTest
   def test_returns_200_response_code_for_options_request
-    options '/api/v1/registrant/auth/eid', {}
+    options '/api/v1/registrant/auth/eid', {}, { 'Origin' => 'https://example.com' }
 
     assert_equal('200', response.code)
   end
@@ -10,7 +10,7 @@ class RegistrantApiCorsHeadersTest < ApplicationIntegrationTest
   def test_returns_expected_headers_for_options_requests
     options '/api/v1/registrant/auth/eid', {}, { 'Origin' => 'https://example.com' }
 
-    assert_equal('*', response.headers['Access-Control-Allow-Origin'])
+    assert_equal('https://example.com', response.headers['Access-Control-Allow-Origin'])
     assert_equal('POST, GET, PUT, PATCH, DELETE, OPTIONS',
                  response.headers['Access-Control-Allow-Methods'])
     assert_equal('Origin, Content-Type, Accept, Authorization, Token, Auth-Token, Email, ' \
@@ -20,16 +20,16 @@ class RegistrantApiCorsHeadersTest < ApplicationIntegrationTest
   end
 
   def test_returns_empty_body
-    options '/api/v1/registrant/auth/eid', {}
+    options '/api/v1/registrant/auth/eid', { 'Origin' => 'https://example.com' }
 
     assert_equal('', response.body)
   end
 
   def test_it_returns_cors_headers_for_other_requests
-    post '/api/v1/registrant/auth/eid', {}
-    assert_equal('*', response.headers['Access-Control-Allow-Origin'])
+    post '/api/v1/registrant/auth/eid', {}, { 'Origin' => 'https://example.com' }
+    assert_equal('https://example.com', response.headers['Access-Control-Allow-Origin'])
 
-    get '/api/v1/registrant/contacts', {}
-    assert_equal('*', response.headers['Access-Control-Allow-Origin'])
+    get '/api/v1/registrant/contacts', {}, { 'Origin' => 'https://example.com' }
+    assert_equal('https://example.com', response.headers['Access-Control-Allow-Origin'])
   end
 end

--- a/test/integration/api/registrant/registrant_api_cors_headers_test.rb
+++ b/test/integration/api/registrant/registrant_api_cors_headers_test.rb
@@ -24,4 +24,12 @@ class RegistrantApiCorsHeadersTest < ApplicationIntegrationTest
 
     assert_equal('', response.body)
   end
+
+  def test_it_returns_cors_headers_for_other_requests
+    post '/api/v1/registrant/auth/eid', {}
+    assert_equal('*', response.headers['Access-Control-Allow-Origin'])
+
+    get '/api/v1/registrant/contacts', {}
+    assert_equal('*', response.headers['Access-Control-Allow-Origin'])
+  end
 end


### PR DESCRIPTION
Should return `Access-Control-Allow-Origin` for all requests, and that should be the original URL of the requester.

Previously partly handled by the web server configuration.