### PR TITLE
Fix bootstrap task that does not load the environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Manual demo install and database setup:
     cp config/application-example.yml config/application.yml # and edit it
     cp config/database-example.yml config/database.yml # and edit it
     bundle exec rake db:setup:all # for production, please follow deployment howto
-    bundle exec rake:bootstrap
+    bundle exec rake bootstrap
     bundle exec rake assets:precompile
 
 ### Apache with patched mod_epp (Debian 7/Ubuntu 14.04 LTS)

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('../config/application', __FILE__)
+require File.expand_path('../config/environment', __FILE__)
 
 Rails.application.load_tasks

--- a/lib/tasks/bootstrap.rake
+++ b/lib/tasks/bootstrap.rake
@@ -1,11 +1,11 @@
 desc 'Bootstraps production-like environment'
 task :bootstrap do
   AdminUser.create!(
-      username: 'admin',
-      email: 'admin@domain.tld',
-      password: 'adminadmin',
-      password_confirmation: 'adminadmin',
-      country_code: 'US',
-      roles: ['admin']
+    username: 'admin',
+    email: 'admin@domain.tld',
+    password: 'adminadmin',
+    password_confirmation: 'adminadmin',
+    country_code: 'US',
+    roles: ['admin']
   )
 end


### PR DESCRIPTION
Fixes #1019.

Change also affects other rake tasks, such as `domain:discard`. I checked them locally, seems to be in order, but please test on staging just in case.

Unfortunately there's no easy way to write an automated test for this case, as the issue seems to be the application not loading when the task is run. In test, the application is already loaded.

Related Rails issue:
https://github.com/rails/rails/issues/28452