### PR TITLE
Support IE11

### DIFF
--- a/app/assets/javascripts/admin-manifest.coffee
+++ b/app/assets/javascripts/admin-manifest.coffee
@@ -8,6 +8,10 @@
 #= require jquery-ui/datepicker
 #= require select2
 #= require jquery.doubleScroll
+
+# Load order does matter
+#= require polyfills/node_list_for_each
+
 #= require datepicker
 #= require spell_check
 #= require admin/application

--- a/app/assets/javascripts/polyfills/node_list_for_each.js
+++ b/app/assets/javascripts/polyfills/node_list_for_each.js
@@ -1,0 +1,11 @@
+// Needed mainly for IE11
+// https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach
+
+if (window.NodeList && !NodeList.prototype.forEach) {
+    NodeList.prototype.forEach = function (callback, thisArg) {
+        thisArg = thisArg || window;
+        for (var i = 0; i < this.length; i++) {
+            callback.call(thisArg, this[i], i, this);
+        }
+    };
+}

--- a/app/assets/javascripts/registrant-manifest.coffee
+++ b/app/assets/javascripts/registrant-manifest.coffee
@@ -4,5 +4,9 @@
 #= require jquery-ui/datepicker
 #= require select2
 #= require datepicker
+
+# Load order does matter
+#= require polyfills/node_list_for_each
+
 #= require spell_check
 #= require shared/general

--- a/app/assets/javascripts/registrar-manifest.coffee
+++ b/app/assets/javascripts/registrar-manifest.coffee
@@ -6,6 +6,10 @@
 #= require jquery-ui/datepicker
 #= require select2
 #= require datepicker
+
+# Load order does matter
+#= require polyfills/node_list_for_each
+
 #= require spell_check
 #= require popover
 #= require text_field_trimmer

--- a/app/assets/javascripts/spell_check.js
+++ b/app/assets/javascripts/spell_check.js
@@ -1,11 +1,13 @@
-(function() {
+(function () {
     function disableSpellCheck() {
         let selector = 'input[type=text], textarea';
         let textFields = document.querySelectorAll(selector);
 
-        for (let field of textFields) {
-            field.spellcheck = false;
-        }
+        textFields.forEach(
+            function (field, _currentIndex, _listObj) {
+                field.spellcheck = false;
+            }
+        );
     }
 
     disableSpellCheck();

--- a/app/assets/javascripts/text_field_trimmer.js
+++ b/app/assets/javascripts/text_field_trimmer.js
@@ -2,13 +2,15 @@
     function trimTextFields() {
         let selector = 'input[type=text], input[type=search], input[type=email], textarea';
         let textFields = document.querySelectorAll(selector);
-        let listener = function () {
+        let changeListener = function () {
             this.value = this.value.trim();
         };
 
-        for (let field of textFields) {
-            field.addEventListener('change', listener);
-        }
+        textFields.forEach(
+            function (field, currentIndex, listObj) {
+                field.addEventListener('change', changeListener);
+            }
+        );
     }
 
     trimTextFields();

--- a/config/application-example.yml
+++ b/config/application-example.yml
@@ -152,3 +152,9 @@ same_site_session_cookies: 'false' # false|strict|lax
 test:
   payments_seb_bank_certificate: 'test/fixtures/files/seb_bank_cert.pem'
   payments_seb_seller_private: 'test/fixtures/files/seb_seller_key.pem'
+
+# Airbrake // Errbit:
+airbrake_host: "https://your-errbit-host.ee"
+# airbrake_env: "staging", defaults to Rails.env
+airbrake_project_id: "1"
+airbrake_project_key: "api_key"

--- a/config/initializers/errbit.rb
+++ b/config/initializers/errbit.rb
@@ -1,0 +1,22 @@
+module Patches
+  module Airbrake
+    module SyncSender
+      def build_https(uri)
+        super.tap do |req|
+          req.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        end
+      end
+    end
+  end
+end
+
+Airbrake::SyncSender.prepend(::Patches::Airbrake::SyncSender)
+
+Airbrake.configure do |config|
+  config.host = ENV['airbrake_host']
+  config.project_id = ENV['airbrake_project_id']
+  config.project_key = ENV['airbrake_project_key']
+
+  config.environment = ENV['airbrake_env'] || Rails.env
+  config.ignore_environments = %w(development test)
+end


### PR DESCRIPTION
Previously `let of` loop was used, which isn't supported in IE11.

It seems it just fails when there is some JS syntax error
(doesn't matter where exactly) and `dataType: 'json'` has no effect.

Closes #982