### PR TITLE
Remove `SyslogLogger` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,6 @@ end if Bundler::VERSION < '2'
 source 'https://rubygems.org'
 
 # core
-
-gem 'SyslogLogger', '2.0', require: 'syslog/logger'
 gem 'iso8601',      '0.8.6' # for dates and times
 gem 'rails',        '4.2.11' # when update, all initializers eis_custom files needs check/update
 gem 'rest-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,6 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    SyslogLogger (2.0)
     actionmailer (4.2.11)
       actionpack (= 4.2.11)
       actionview (= 4.2.11)
@@ -445,7 +444,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  SyslogLogger (= 2.0)
   active_model-errors_details
   activerecord-import (= 0.7.0)
   airbrake

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,6 +49,7 @@ Rails.application.configure do
   config.log_tags = [:subdomain, :uuid, :remote_ip]
 
   # Use a different logger for distributed setups.
+  require 'syslog/logger'
   config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new(ENV['app_name'] || 'registry'))
 
   # Use a different cache store in production.


### PR DESCRIPTION
It is present in Ruby Standard Library since version 2.0
https://github.com/seattlerb/sysloglogger

Affects production config, needs verification.