### PR TITLE
update rack to 1.6.11

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,7 +287,7 @@ GEM
       erubis
       que (~> 0.8)
       sinatra
-    rack (1.6.10)
+    rack (1.6.11)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-protection (1.5.5)


### PR DESCRIPTION
Affected by: https://access.redhat.com/security/cve/cve-2018-16471