### PR TITLE
Remove unused JSON key

### DIFF
--- a/app/models/whois_record.rb
+++ b/app/models/whois_record.rb
@@ -33,7 +33,6 @@ class WhoisRecord < ActiveRecord::Base
 
     registrant = domain.registrant
 
-    @disclosed = []
     h[:disclaimer] = disclaimer_text if disclaimer_text.present?
     h[:name]       = domain.name
     h[:status]     = domain.statuses.map { |x| status_map[x] || x }
@@ -52,12 +51,10 @@ class WhoisRecord < ActiveRecord::Base
     end
 
     h[:email] = registrant.email
-    @disclosed << [:email, registrant.email]
     h[:registrant_changed]          = registrant.updated_at.try(:to_s, :iso8601)
 
     h[:admin_contacts] = []
     domain.admin_contacts.each do |ac|
-      @disclosed << [:email, ac.email]
       h[:admin_contacts] << {
           name: ac.name,
           email: ac.email,
@@ -66,7 +63,6 @@ class WhoisRecord < ActiveRecord::Base
     end
     h[:tech_contacts] = []
     domain.tech_contacts.each do |tc|
-      @disclosed << [:email, tc.email]
       h[:tech_contacts] << {
           name: tc.name,
           email: tc.email,
@@ -88,7 +84,6 @@ class WhoisRecord < ActiveRecord::Base
     h[:dnssec_changed] = domain.dnskeys.pluck(:updated_at).max.try(:to_s, :iso8601) rescue nil
 
 
-    h[:disclosed] = @disclosed
     h
   end
 


### PR DESCRIPTION
Deploy along with https://github.com/internetee/rest-whois/pull/163 and https://github.com/internetee/whois/pull/40.

Previously `registry` app was generating `whois_record.json['disclosed']` key which wasn't used neither by `rest-whois` nor by `whois` project.

It seems it was meant for https://github.com/internetee/registry/issues/992 initially, but I see no benefit leaving it.

Existing records will still have this key (until regeneration over time), should not create any problem.

---
Currently all emails of admin/tech contacts are mixed in a single collection that looks as follows:

```
  "disclosed": [
    [
      "email",
      "john@inbox.test"
    ],
    [
      "email",
      "john@inbox.test"
    ],
    [
      "email",
      "john@inbox.test"
    ]
  ]
```

Is this what you wanted to reuse in https://github.com/internetee/registry/issues/992#issuecomment-438037334? If so, we will first need to parse current state of WHOIS database to distinguish registrant email from admin/tech contact emails, and then regenerate the whole WHOIS database with new structure. It's kinda error-prone.

@vohmar Needs your input.