### PR TITLE
Remove override from transfer_wait_time

### DIFF
--- a/config/initializers/initial_settings.rb
+++ b/config/initializers/initial_settings.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 # otherwise rake not working 100%
 begin
   con = ActiveRecord::Base.connection
@@ -23,7 +24,6 @@ if con.present? && con.table_exists?('settings')
   Setting.save_default(:ns_max_count, 11)
 
   Setting.save_default(:transfer_wait_time, 0)
-  Setting.transfer_wait_time = 0
   Setting.save_default(:request_confrimation_on_registrant_change_enabled, true)
   Setting.save_default(:request_confirmation_on_domain_deletion_enabled, true)
   Setting.save_default(:address_processing, true)


### PR DESCRIPTION
Previous behavior was a bug: 

on every restart of the server, transfer_wait_time was reset to 0.