### PR TITLE
Registry 992

### DIFF
--- a/app/models/concerns/contact/disclosable.rb
+++ b/app/models/concerns/contact/disclosable.rb
@@ -1,0 +1,26 @@
+module Concerns
+  module Contact
+    module Disclosable
+      extend ActiveSupport::Concern
+
+      class_methods do
+        attr_accessor :disclosable_attributes
+      end
+
+      included do
+        self.disclosable_attributes = %w[name email]
+        validate :validate_disclosed_attributes
+      end
+
+      private
+
+      def validate_disclosed_attributes
+        return if disclosed_attributes.empty?
+
+        has_undisclosable_attributes = (disclosed_attributes - self.class.disclosable_attributes)
+                                       .any?
+        errors.add(:disclosed_attributes, :invalid) if has_undisclosable_attributes
+      end
+    end
+  end
+end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -4,6 +4,7 @@ class Contact < ActiveRecord::Base
   include UserEvents
   include Concerns::Contact::Transferable
   include Concerns::Contact::Identical
+  include Concerns::Contact::Disclosable
 
   belongs_to :original, class_name: self.name
   belongs_to :registrar, required: true

--- a/app/models/whois_record.rb
+++ b/app/models/whois_record.rb
@@ -52,22 +52,18 @@ class WhoisRecord < ActiveRecord::Base
 
     h[:email] = registrant.email
     h[:registrant_changed]          = registrant.updated_at.try(:to_s, :iso8601)
+    h[:registrant_disclosed_attributes] = registrant.disclosed_attributes
 
     h[:admin_contacts] = []
-    domain.admin_contacts.each do |ac|
-      h[:admin_contacts] << {
-          name: ac.name,
-          email: ac.email,
-          changed: ac.updated_at.try(:to_s, :iso8601)
-      }
+
+    domain.admin_contacts.each do |contact|
+      h[:admin_contacts] << contact_json_hash(contact)
     end
+
     h[:tech_contacts] = []
-    domain.tech_contacts.each do |tc|
-      h[:tech_contacts] << {
-          name: tc.name,
-          email: tc.email,
-          changed: tc.updated_at.try(:to_s, :iso8601)
-      }
+
+    domain.tech_contacts.each do |contact|
+      h[:tech_contacts] << contact_json_hash(contact)
     end
 
     # update registar triggers when adding new attributes
@@ -108,5 +104,14 @@ class WhoisRecord < ActiveRecord::Base
 
   def disclaimer_text
     Setting.registry_whois_disclaimer
+  end
+
+  def contact_json_hash(contact)
+    {
+      name: contact.name,
+      email: contact.email,
+      changed: contact.updated_at.try(:to_s, :iso8601),
+      disclosed_attributes: contact.disclosed_attributes,
+    }
   end
 end

--- a/app/views/admin/registrars/form/_billing.html.erb
+++ b/app/views/admin/registrars/form/_billing.html.erb
@@ -51,7 +51,7 @@
                 <div class="form-group">
                     <% if f.object.new_record? %>
                         <div class="col-md-offset-4 col-md-8">
-                            <%= t '.no_reference_no_hint' %>
+                            <%= t '.no_reference_number_hint' %>
                         </div>
                     <% else %>
                         <div class="col-md-4 control-label">
@@ -60,7 +60,7 @@
 
                         <div class="col-md-7">
                             <%= f.text_field :reference_no, disabled: true,
-                                             title: t('.disabled_reference_no_hint'),
+                                             title: t('.disabled_reference_number_hint'),
                                              class: 'form-control' %>
                         </div>
                     <% end %>

--- a/config/locales/admin/registrars.en.yml
+++ b/config/locales/admin/registrars.en.yml
@@ -35,8 +35,8 @@ en:
 
         billing:
           header: Billing
-          no_reference_no_hint: Reference number will be generated automatically
-          disabled_reference_no_hint: Reference number cannot be changed
+          no_reference_number_hint: Reference number will be generated automatically
+          disabled_reference_number_hint: Reference number cannot be changed
 
         preferences:
           header: Preferences

--- a/config/locales/contacts.en.yml
+++ b/config/locales/contacts.en.yml
@@ -26,3 +26,5 @@ en:
               not_uniq: 'not uniq'
             country_code:
               invalid: Country code is not valid, should be in ISO_3166-1 alpha 2 format (%{value})
+            disclosed_attributes:
+              invalid: contain unsupported attribute(s)

--- a/db/migrate/20181108154921_add_contacts_disclosed_attributes.rb
+++ b/db/migrate/20181108154921_add_contacts_disclosed_attributes.rb
@@ -1,0 +1,5 @@
+class AddContactsDisclosedAttributes < ActiveRecord::Migration
+  def change
+    add_column :contacts, :disclosed_attributes, :string, array: true, default: [], null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -671,7 +671,8 @@ CREATE TABLE public.contacts (
     ident_updated_at timestamp without time zone,
     upid integer,
     up_date timestamp without time zone,
-    uuid uuid DEFAULT public.gen_random_uuid() NOT NULL
+    uuid uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    disclosed_attributes character varying[] DEFAULT '{}'::character varying[] NOT NULL
 );
 
 
@@ -4860,4 +4861,6 @@ INSERT INTO schema_migrations (version) VALUES ('20180826162821');
 INSERT INTO schema_migrations (version) VALUES ('20181001090536');
 
 INSERT INTO schema_migrations (version) VALUES ('20181002090319');
+
+INSERT INTO schema_migrations (version) VALUES ('20181108154921');
 

--- a/doc/registrant-api/v1/contact.md
+++ b/doc/registrant-api/v1/contact.md
@@ -91,13 +91,14 @@ Content-Type: application/json
   "auth_info": "password",
   "statuses": [
     "ok"
-  ]
+  ],
+  "disclosed_attributes": ["name"]
 }
 ```
 
 ## PATCH /api/v1/registrant/contacts/$UUID
 
-Update contact details for a contact.
+Update contact.
 
 #### Parameters
 
@@ -112,6 +113,7 @@ Update contact details for a contact.
 | address[city]         | false    | String |                | New city name                                             |
 | address[state]        | false    | String |                | New state name                                            |
 | address[country_code] | false    | String |                | New country code in 2 letter format (ISO 3166-1 alpha-2)  |
+| disclosed_attributes  | false    | Array  |                | Possible values: "name", "email"
 
 
 #### Request
@@ -132,7 +134,8 @@ Content-type: application/json
     "city":"New City",
     "state":"New state",
     "country_code":"LV"
-  }
+  },
+  "disclosed_attributes": ["name"]
 }
 
 ```

--- a/lib/serializers/registrant_api/contact.rb
+++ b/lib/serializers/registrant_api/contact.rb
@@ -28,7 +28,8 @@ module Serializers
             country_code: contact.country_code,
           },
           auth_info: contact.auth_info,
-          statuses: contact.statuses
+          statuses: contact.statuses,
+          disclosed_attributes: contact.disclosed_attributes,
         }
       end
     end

--- a/test/models/contact/disclosable_test.rb
+++ b/test/models/contact/disclosable_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class ContactDisclosableTest < ActiveSupport::TestCase
+  setup do
+    @contact = contacts(:john)
+    @original_disclosable_attributes = Contact.disclosable_attributes
+  end
+
+  teardown do
+    Contact.disclosable_attributes = @original_disclosable_attributes
+  end
+
+  def test_no_disclosed_attributes_by_default
+    assert_empty Contact.new.disclosed_attributes
+  end
+
+  def test_disclosable_attributes
+    assert_equal %w[name email], Contact.disclosable_attributes
+  end
+
+  def test_valid_without_disclosed_attributes
+    @contact.disclosed_attributes = []
+    assert @contact.valid?
+  end
+
+  def test_invalid_when_attribute_is_not_disclosable
+    Contact.disclosable_attributes = %w[some disclosable]
+    @contact.disclosed_attributes = %w[some undisclosable]
+
+    assert @contact.invalid?
+    assert_includes @contact.errors.get(:disclosed_attributes), 'contain unsupported attribute(s)'
+  end
+
+  def test_valid_when_attribute_is_disclosable
+    Contact.disclosable_attributes = %w[some disclosable]
+    @contact.disclosed_attributes = %w[disclosable]
+    assert @contact.valid?
+  end
+end

--- a/test/models/contact_test.rb
+++ b/test/models/contact_test.rb
@@ -6,7 +6,7 @@ class ContactTest < ActiveSupport::TestCase
   end
 
   def test_valid_fixture
-    assert @contact.valid?
+    assert @contact.valid?, proc { @contact.errors.full_messages }
   end
 
   def test_invalid_without_email

--- a/test/models/whois_record_test.rb
+++ b/test/models/whois_record_test.rb
@@ -39,12 +39,13 @@ class WhoisRecordTest < ActiveSupport::TestCase
   end
 
   def test_generates_json_with_registrant
-    registrant = contacts(:john).becomes(Registrant)
-    registrant.update!(name: 'John', kind: 'priv', email: 'john@shop.test',
-                       updated_at: Time.zone.parse('2010-07-05'))
+    contact = contacts(:john)
+    contact.update!(name: 'John', kind: 'priv', email: 'john@shop.test',
+                    updated_at: Time.zone.parse('2010-07-05'),
+                    disclosed_attributes: %w[name])
 
     domain = domains(:shop)
-    domain.update!(registrant: registrant)
+    domain.update!(registrant: contact.becomes(Registrant))
 
     whois_record = whois_records(:shop)
     whois_record.update!(json: {})
@@ -54,12 +55,14 @@ class WhoisRecordTest < ActiveSupport::TestCase
     assert_equal 'priv', generated_json[:registrant_kind]
     assert_equal 'john@shop.test', generated_json[:email]
     assert_equal '2010-07-05T00:00:00+03:00', generated_json[:registrant_changed]
+    assert_equal %w[name], generated_json[:registrant_disclosed_attributes]
   end
 
   def test_generates_json_with_admin_contacts
     contact = contacts(:john)
     contact.update!(name: 'John', email: 'john@shop.test',
-                    updated_at: Time.zone.parse('2010-07-05'))
+                    updated_at: Time.zone.parse('2010-07-05'),
+                    disclosed_attributes: %w[name])
 
     domain = domains(:shop)
     domain.admin_contacts = [contact]
@@ -71,12 +74,14 @@ class WhoisRecordTest < ActiveSupport::TestCase
     assert_equal 'John', admin_contact_json[:name]
     assert_equal 'john@shop.test', admin_contact_json[:email]
     assert_equal '2010-07-05T00:00:00+03:00', admin_contact_json[:changed]
+    assert_equal %w[name], admin_contact_json[:disclosed_attributes]
   end
 
   def test_generates_json_with_tech_contacts
     contact = contacts(:john)
     contact.update!(name: 'John', email: 'john@shop.test',
-                    updated_at: Time.zone.parse('2010-07-05'))
+                    updated_at: Time.zone.parse('2010-07-05'),
+                    disclosed_attributes: %w[name])
 
     domain = domains(:shop)
     domain.tech_contacts = [contact]
@@ -88,5 +93,6 @@ class WhoisRecordTest < ActiveSupport::TestCase
     assert_equal 'John', tech_contact_json[:name]
     assert_equal 'john@shop.test', tech_contact_json[:email]
     assert_equal '2010-07-05T00:00:00+03:00', tech_contact_json[:changed]
+    assert_equal %w[name], tech_contact_json[:disclosed_attributes]
   end
 end


### PR DESCRIPTION
Requires #1039
Do not deploy until #1038 is solved.
Closes #992.

This PR contains only API part. WHOIS and REST-WHOIS "front-end" parts will be implemented in respective projects. 
It's needed to verify that API populates `registrant_disclosed_attributes` and `disclosed_attributes` JSON keys to WHOIS database.