### PR TITLE
Deprecate custom test case for rake tasks

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
   config.active_support.test_order = :random
 
-  config.active_support.deprecation = :raise
+  config.active_support.deprecation = :stderr
   config.logger = ActiveSupport::Logger.new(nil)
 
   config.action_view.raise_on_missing_translations = true

--- a/test/support/task_test_case.rb
+++ b/test/support/task_test_case.rb
@@ -4,6 +4,8 @@ class TaskTestCase < ActiveSupport::TestCase
     # This suppresses default stdout and makes Rails.env.test? checks unnecessary.
     @original_stdout = $stdout
     $stdout = File.open(File::NULL, 'w')
+    ActiveSupport::Deprecation.warn('`TaskTestCase` class will be removed soon.' \
+                                    ' Use `capture_io` and `assert_output` instead')
   end
 
   teardown do


### PR DESCRIPTION
Does not affect production code.