### PR TITLE
Support JSON only

### DIFF
--- a/app/controllers/api/v1/registrant/contacts_controller.rb
+++ b/app/controllers/api/v1/registrant/contacts_controller.rb
@@ -53,7 +53,8 @@ module Api
 
           if disclosed_attributes
             if contact.org?
-              error_msg = "Legal person's data cannot be concealed. Please remove this parameter."
+              error_msg = "Legal person's data is visible by default and cannot be concealed." \
+                          ' Please remove this parameter.'
               render json: { errors: [{ disclosed_attributes: [error_msg] }] }, status: :bad_request
               return
             end

--- a/app/controllers/registrant/contacts_controller.rb
+++ b/app/controllers/registrant/contacts_controller.rb
@@ -106,13 +106,15 @@ class Registrant::ContactsController < RegistrantController
 
   def normalize_address_attributes_for_api(params)
     normalized = params
+    address_parts = {}
 
     Contact.address_attribute_names.each do |attr|
       attr = attr.to_sym
-      normalized["address[#{attr}]"] = params[attr]
+      address_parts[attr] = params[attr]
       normalized.delete(attr)
     end
 
+    normalized[:address] = address_parts
     normalized
   end
 
@@ -120,7 +122,8 @@ class Registrant::ContactsController < RegistrantController
     uri = URI.parse("#{ENV['registrant_api_base_url']}/api/v1/registrant/contacts/#{uuid}")
     request = Net::HTTP::Patch.new(uri)
     request['Authorization'] = "Bearer #{access_token}"
-    request.form_data = contact_update_api_params
+    request['Content-type'] = 'application/json'
+    request.body = contact_update_api_params.to_json
 
     Net::HTTP.start(uri.hostname, uri.port, use_ssl: (uri.scheme == 'https')) do |http|
       http.request(request)

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -12,4 +12,5 @@
 
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym 'DNS'
+  inflect.irregular 'business_registry_cache', 'business_registry_caches'
 end

--- a/test/fixtures/business_registry_caches.yml
+++ b/test/fixtures/business_registry_caches.yml
@@ -1,8 +1,7 @@
-first:
+one:
   ident: 1234
   ident_country_code: US
-  associated_businesses:
-    - 1234
+  associated_businesses: []
   retrieved_on: 2010-07-05 10:30
   created_at: 2010-07-05 10:30
   updated_at: 2010-07-05 10:30

--- a/test/integration/api/v1/registrant/contacts/update_test.rb
+++ b/test/integration/api/v1/registrant/contacts/update_test.rb
@@ -160,7 +160,9 @@ class RegistrantApiV1ContactUpdateTest < ActionDispatch::IntegrationTest
   end
 
   def test_legal_persons_disclosed_attributes_cannot_be_changed
+    business_registry_caches(:one).update!(associated_businesses: %w[1234])
     @contact.update!(ident_type: Contact::ORG,
+                     ident: '1234',
                      disclosed_attributes: %w[])
 
     assert_no_changes -> { @contact.disclosed_attributes } do

--- a/test/system/registrant_area/contacts/update_test.rb
+++ b/test/system/registrant_area/contacts/update_test.rb
@@ -34,8 +34,9 @@ class RegistrantAreaContactUpdateTest < ApplicationIntegrationTest
   def test_update_contact
     stub_auth_request
 
-    request_body = { name: 'new name', email: 'new@inbox.test', phone: '+666.6' }
-    headers = { 'Authorization' => 'Bearer test-access-token' }
+    request_body = { name: 'new name', email: 'new@inbox.test', phone: '+666.6' }.to_json
+    headers = { 'Content-Type' => Mime::JSON,
+                'Authorization' => 'Bearer test-access-token' }
     url = "https://api.test/api/v1/registrant/contacts/#{@contact.uuid}"
     update_request_stub = stub_request(:patch, url).with(body: request_body, headers: headers)
                             .to_return(body: '{}', status: 200)
@@ -104,17 +105,18 @@ class RegistrantAreaContactUpdateTest < ApplicationIntegrationTest
     Setting.address_processing = true
     stub_auth_request
 
-    request_body = { email: 'john@inbox.test',
-                     name: 'John',
+    request_body = { name: 'John',
+                     email: 'john@inbox.test',
                      phone: '+555.555',
                      address: {
+                       city: 'new city',
                        street: 'new street',
                        zip: '93742',
-                       city: 'new city',
+                       country_code: 'AT',
                        state: 'new state',
-                       country_code: 'AT'
-                     } }
-    headers = { 'Authorization' => 'Bearer test-access-token' }
+                     } }.to_json
+    headers = { 'Content-type' => 'application/json',
+                'Authorization' => 'Bearer test-access-token' }
     url = "https://api.test/api/v1/registrant/contacts/#{@contact.uuid}"
     update_request_stub = stub_request(:patch, url).with(body: request_body, headers: headers)
                             .to_return(body: '{}', status: 200)


### PR DESCRIPTION
This effectively fixes `registry-992`, which is already in master.

Contact update endpoint in Registrant API needs to be completely retested.