### PR TITLE
Fix reference number generation algorithm

### DIFF
--- a/app/models/billing/reference_no/base.rb
+++ b/app/models/billing/reference_no/base.rb
@@ -26,8 +26,8 @@ module Billing
         next_number = number
 
         loop do
-          next_number = next_number.next
           return next_number if next_number.to_s.end_with?('0')
+          next_number = next_number.next
         end
       end
 

--- a/test/models/billing/reference_no/base_test.rb
+++ b/test/models/billing/reference_no/base_test.rb
@@ -15,6 +15,7 @@ class ReferenceNoBaseTest < ActiveSupport::TestCase
   def test_generates_check_digit_for_a_given_base
     assert_equal 3, Billing::ReferenceNo::Base.new('1').check_digit
     assert_equal 7, Billing::ReferenceNo::Base.new('1234567891234567891').check_digit
+    assert_equal 0, Billing::ReferenceNo::Base.new('773423').check_digit
   end
 
   def test_returns_string_representation


### PR DESCRIPTION
Some generated reference nubers came out invalid - it seems that in some cases our currect algorithm resulted with control value of 10 and inserted that in the end of randomly generated prefix while the correct value is 0