### PR TITLE
Update `bootstrap-sass` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'haml-rails', '0.9.0' # haml for views
 gem 'nokogiri'
 
 # style
-gem 'bootstrap-sass', '3.3.5.1' # bootstrap style
+gem 'bootstrap-sass', '~> 3.4'
 gem 'sass-rails',     '5.0.6'   # sass style
 
 # js

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,16 +111,16 @@ GEM
       actionpack
       activesupport (>= 3.0.0)
       rspec
-    autoprefixer-rails (6.7.7.1)
+    autoprefixer-rails (9.4.8)
       execjs
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
     bcrypt (3.1.11)
-    bootstrap-sass (3.3.5.1)
-      autoprefixer-rails (>= 5.0.0.1)
-      sass (>= 3.3.0)
+    bootstrap-sass (3.4.1)
+      autoprefixer-rails (>= 5.2.1)
+      sassc (>= 2.0.0)
     builder (3.2.3)
     bullet (4.14.7)
       activesupport (>= 3.0.0)
@@ -368,6 +368,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sassc (2.0.0)
+      ffi (~> 1.9.6)
+      rake
     savon (2.11.1)
       akami (~> 1.2)
       builder (>= 2.1.2)
@@ -448,7 +451,7 @@ DEPENDENCIES
   activerecord-import (= 0.7.0)
   airbrake
   autodoc
-  bootstrap-sass (= 3.3.5.1)
+  bootstrap-sass (~> 3.4)
   bullet (= 4.14.7)
   cancancan (= 1.11.0)
   capybara


### PR DESCRIPTION
Fixes CVE-2019-8331
https://nvd.nist.gov/vuln/detail/CVE-2019-8331