### PR TITLE
Remove `domains.reserved` database column as unused

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -79,7 +79,6 @@ class Domain < ActiveRecord::Base
     self.status_notes = {} if status_notes.nil?
   end
 
-  before_create -> { self.reserved = in_reserved_list?; nil }
   before_save :manage_automatic_statuses
   before_save :touch_always_version
   def touch_always_version

--- a/app/models/domain_status.rb
+++ b/app/models/domain_status.rb
@@ -72,7 +72,6 @@ class DomainStatus < ActiveRecord::Base
   FORCE_DELETE = 'serverForceDelete'
   DELETE_CANDIDATE = 'deleteCandidate'
   EXPIRED = 'expired'
-  RESERVED = 'reserved'
 
   STATUSES = [
     CLIENT_DELETE_PROHIBITED, SERVER_DELETE_PROHIBITED, CLIENT_HOLD, SERVER_HOLD,

--- a/db/migrate/20190319133036_remove_domains_reserved.rb
+++ b/db/migrate/20190319133036_remove_domains_reserved.rb
@@ -1,0 +1,5 @@
+class RemoveDomainsReserved < ActiveRecord::Migration
+  def change
+    remove_column :domains, :reserved
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -938,7 +938,6 @@ CREATE TABLE public.domains (
     pending_json jsonb,
     force_delete_date date,
     statuses character varying[],
-    reserved boolean DEFAULT false,
     status_notes public.hstore,
     statuses_before_force_delete character varying[] DEFAULT '{}'::character varying[],
     upid integer,
@@ -4934,6 +4933,8 @@ INSERT INTO schema_migrations (version) VALUES ('20190209150026');
 INSERT INTO schema_migrations (version) VALUES ('20190311111718');
 
 INSERT INTO schema_migrations (version) VALUES ('20190312211614');
+
+INSERT INTO schema_migrations (version) VALUES ('20190319133036');
 
 INSERT INTO schema_migrations (version) VALUES ('20190322152123');
 

--- a/doc/registrant-api/v1/domain.md
+++ b/doc/registrant-api/v1/domain.md
@@ -96,7 +96,6 @@ Content-Type: application/json
       },
 
     ],
-    "reserved":false,
     "status_notes":{
 
     },
@@ -212,7 +211,6 @@ Content-Type: application/json
       },
 
     ],
-    "reserved":false,
     "status_notes":{
 
     },
@@ -319,7 +317,6 @@ Content-Type: application/json
       ]
     }
   ],
-  "reserved":false,
   "status_notes":{
 
   },

--- a/doc/registrant-api/v1/registry_lock.md
+++ b/doc/registrant-api/v1/registry_lock.md
@@ -97,7 +97,6 @@ Content-Type: application/json
       ]
     }
   ],
-  "reserved":false,
   "status_notes":{
 
   },
@@ -240,7 +239,6 @@ Content-Type: application/json
       ]
     }
   ],
-  "reserved":false,
   "status_notes":{
 
   },

--- a/doc/repp/v1/domain.md
+++ b/doc/repp/v1/domain.md
@@ -61,7 +61,6 @@ Content-Type: application/json
       "statuses": [
         "ok"
       ],
-      "reserved": false,
       "status_notes": {
       }
     }

--- a/lib/serializers/registrant_api/domain.rb
+++ b/lib/serializers/registrant_api/domain.rb
@@ -43,7 +43,6 @@ module Serializers
           force_delete_date: domain.force_delete_date,
           statuses: domain.statuses,
           locked_by_registrant_at: domain.locked_by_registrant_at,
-          reserved: domain.reserved,
           status_notes: domain.status_notes,
           nameservers: nameservers,
         }

--- a/test/lib/serializers/registrant_api/domain_test.rb
+++ b/test/lib/serializers/registrant_api/domain_test.rb
@@ -74,7 +74,7 @@ class SerializersRegistrantApiDomainTest < ActiveSupport::TestCase
               period_unit creator_str updator_str legacy_id legacy_registrar_id legacy_registrant_id
               outzone_at delete_at registrant_verification_asked_at
               registrant_verification_token pending_json force_delete_date statuses
-              locked_by_registrant_at reserved status_notes nameservers]
+              locked_by_registrant_at status_notes nameservers]
 
     assert_equal(keys, @json.keys & keys)
   end


### PR DESCRIPTION
This change affects Registrant and REST EPP APis.

@vohmar I doubt it will be a problem for Registrant API, but maybe there is some registrar who uses `reserved` field from REST EPP API? (`/repp/v1/domains` endpoint)?