### PR TITLE
Refactor force delete

### DIFF
--- a/app/models/concerns/domain/force_delete.rb
+++ b/app/models/concerns/domain/force_delete.rb
@@ -12,8 +12,7 @@ module Concerns::Domain::ForceDelete
 
     preserve_current_statuses_for_force_delete
     add_force_delete_statuses
-    self.force_delete_at = (Time.zone.now + (Setting.redemption_grace_period.days + 1.day)).utc
-                             .beginning_of_day
+    self.force_delete_date = Time.zone.today + Setting.redemption_grace_period.days + 1.day
     stop_all_pending_actions
     allow_deletion
     save(validate: false)
@@ -22,7 +21,7 @@ module Concerns::Domain::ForceDelete
   def cancel_force_delete
     restore_statuses_before_force_delete
     remove_force_delete_statuses
-    self.force_delete_at = nil
+    self.force_delete_date = nil
     save(validate: false)
   end
 

--- a/app/models/concerns/domain/releasable.rb
+++ b/app/models/concerns/domain/releasable.rb
@@ -15,13 +15,17 @@ module Concerns
 
         def releasable_domains
           if release_to_auction
-            where('delete_at < ? AND ? != ALL(coalesce(statuses, array[]::varchar[]))',
+            where('(delete_at < ? OR force_delete_date <= ?)' \
+              ' AND ? != ALL(coalesce(statuses, array[]::varchar[]))',
                   Time.zone.now,
+                  Time.zone.today,
                   DomainStatus::SERVER_DELETE_PROHIBITED)
           else
-            where('delete_at < ? AND ? != ALL(coalesce(statuses, array[]::varchar[])) AND' \
+            where('(delete_at < ? OR force_delete_date <= ?)' \
+              ' AND ? != ALL(coalesce(statuses, array[]::varchar[])) AND' \
                   ' ? != ALL(COALESCE(statuses, array[]::varchar[]))',
                   Time.zone.now,
+                  Time.zone.today,
                   DomainStatus::SERVER_DELETE_PROHIBITED,
                   DomainStatus::DELETE_CANDIDATE)
           end

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -501,7 +501,7 @@ class Domain < ActiveRecord::Base
           when DomainStatus::PENDING_DELETE
             self.delete_at = nil
           when DomainStatus::SERVER_MANUAL_INZONE # removal causes server hold to set
-            self.outzone_at = Time.zone.now if self.force_delete_at.present?
+            self.outzone_at = Time.zone.now if force_delete_scheduled?
           when DomainStatus::DomainStatus::EXPIRED # removal causes server hold to set
             self.outzone_at = self.expire_time + 15.day
           when DomainStatus::DomainStatus::SERVER_HOLD # removal causes server hold to set

--- a/app/models/domain_cron.rb
+++ b/app/models/domain_cron.rb
@@ -78,18 +78,4 @@ class DomainCron
     STDOUT << "#{Time.zone.now.utc} - Successfully set server_hold to #{marked} of #{real} domains\n" unless Rails.env.test?
     marked
   end
-
-  def self.destroy_delete_candidates
-    STDOUT << "#{Time.zone.now.utc} - Destroying domains\n" unless Rails.env.test?
-
-    c = 0
-
-    Domain.where('force_delete_date <= ?', Time.zone.now.end_of_day.utc).each do |x|
-      DomainDeleteJob.enqueue(x.id, run_at: rand(((24*60) - (DateTime.now.hour * 60  + DateTime.now.minute))).minutes.from_now)
-      STDOUT << "#{Time.zone.now.utc} DomainCron.destroy_delete_candidates: job added by force delete time ##{x.id} (#{x.name})\n" unless Rails.env.test?
-      c += 1
-    end
-
-    STDOUT << "#{Time.zone.now.utc} - Job destroy added for #{c} domains\n" unless Rails.env.test?
-  end
 end

--- a/app/models/domain_cron.rb
+++ b/app/models/domain_cron.rb
@@ -84,7 +84,7 @@ class DomainCron
 
     c = 0
 
-    Domain.where('force_delete_at <= ?', Time.zone.now.end_of_day.utc).each do |x|
+    Domain.where('force_delete_date <= ?', Time.zone.now.end_of_day.utc).each do |x|
       DomainDeleteJob.enqueue(x.id, run_at: rand(((24*60) - (DateTime.now.hour * 60  + DateTime.now.minute))).minutes.from_now)
       STDOUT << "#{Time.zone.now.utc} DomainCron.destroy_delete_candidates: job added by force delete time ##{x.id} (#{x.name})\n" unless Rails.env.test?
       c += 1

--- a/app/models/whois_record.rb
+++ b/app/models/whois_record.rb
@@ -40,7 +40,8 @@ class WhoisRecord < ActiveRecord::Base
     h[:changed]    = domain.updated_at.try(:to_s, :iso8601)
     h[:expire]     = domain.valid_to.to_date.to_s
     h[:outzone]    = domain.outzone_at.try(:to_date).try(:to_s)
-    h[:delete]     = [domain.delete_at, domain.force_delete_at].compact.min.try(:to_date).try(:to_s)
+    h[:delete] = [domain.delete_at, domain.force_delete_date].compact.min.try(:to_date)
+                                                             .try(:to_s)
 
     h[:registrant] = registrant.name
     h[:registrant_kind] = registrant.kind

--- a/app/presenters/domain_presenter.rb
+++ b/app/presenters/domain_presenter.rb
@@ -39,7 +39,7 @@ class DomainPresenter
   end
 
   def force_delete_date
-    view.l(domain.force_delete_at, format: :date) if domain.force_delete_at
+    view.l(domain.force_delete_date) if domain.force_delete_scheduled?
   end
 
   def admin_contact_names

--- a/app/views/admin/domains/partials/_general.html.erb
+++ b/app/views/admin/domains/partials/_general.html.erb
@@ -31,8 +31,8 @@
             <dt><%= t('.delete_time') %></dt>
             <dd><%= l(@domain.delete_at) %></dd>
 
-            <dt><%= Domain.human_attribute_name :force_delete_at %></dt>
-            <dd><%= l @domain.force_delete_at %></dd>
+            <dt><%= Domain.human_attribute_name :force_delete_date %></dt>
+            <dd><%= l @domain.force_delete_date %></dd>
 
             <dt><%= t('.locked_by_registrant_at') %></dt>
             <dd><%= l(@domain.locked_by_registrant_at) %></dd>

--- a/app/views/registrant/domains/partials/_general.html.erb
+++ b/app/views/registrant/domains/partials/_general.html.erb
@@ -31,8 +31,8 @@
             <dt><%= Domain.human_attribute_name :delete_at %></dt>
             <dd><%= l(@domain.delete_at) %></dd>
 
-            <dt><%= Domain.human_attribute_name :force_delete_at %></dt>
-            <dd><%= l(@domain.force_delete_at) %></dd>
+            <dt><%= Domain.human_attribute_name :force_delete_date %></dt>
+            <dd><%= l @domain.force_delete_date %></dd>
         </dl>
     </div>
 </div>

--- a/config/locales/admin/domains.en.yml
+++ b/config/locales/admin/domains.en.yml
@@ -52,7 +52,6 @@ en:
         general:
           outzone_time: Outzone time
           delete_time: Delete time
-          force_delete_time: Force delete time
           locked_by_registrant_at: Registry lock time
 
         admin_contacts:

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -38,10 +38,6 @@ if @cron_group == 'registry'
     runner 'Certificate.update_crl'
   end
 
-  every 42.minutes do
-    runner 'DomainCron.destroy_delete_candidates'
-  end
-
   every 45.minutes do
     runner 'DomainCron.start_expire_period'
   end

--- a/db/migrate/20190322152123_change_domains_force_delete_at_to_date.rb
+++ b/db/migrate/20190322152123_change_domains_force_delete_at_to_date.rb
@@ -1,0 +1,5 @@
+class ChangeDomainsForceDeleteAtToDate < ActiveRecord::Migration
+  def change
+    change_column :domains, :force_delete_at, :date
+  end
+end

--- a/db/migrate/20190322152529_rename_domains_force_delete_at_to_force_delete_date.rb
+++ b/db/migrate/20190322152529_rename_domains_force_delete_at_to_force_delete_date.rb
@@ -1,0 +1,5 @@
+class RenameDomainsForceDeleteAtToForceDeleteDate < ActiveRecord::Migration
+  def change
+    rename_column :domains, :force_delete_at, :force_delete_date
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -936,7 +936,7 @@ CREATE TABLE public.domains (
     registrant_verification_asked_at timestamp without time zone,
     registrant_verification_token character varying,
     pending_json jsonb,
-    force_delete_at timestamp without time zone,
+    force_delete_date date,
     statuses character varying[],
     reserved boolean DEFAULT false,
     status_notes public.hstore,
@@ -4934,4 +4934,8 @@ INSERT INTO schema_migrations (version) VALUES ('20190209150026');
 INSERT INTO schema_migrations (version) VALUES ('20190311111718');
 
 INSERT INTO schema_migrations (version) VALUES ('20190312211614');
+
+INSERT INTO schema_migrations (version) VALUES ('20190322152123');
+
+INSERT INTO schema_migrations (version) VALUES ('20190322152529');
 

--- a/doc/registrant-api/v1/domain.md
+++ b/doc/registrant-api/v1/domain.md
@@ -71,7 +71,7 @@ Content-Type: application/json
     "pending_json":{
 
     },
-    "force_delete_at":null,
+    "force_delete_date":null,
     "statuses":[
       "ok"
     ],
@@ -187,7 +187,7 @@ Content-Type: application/json
     "pending_json":{
 
     },
-    "force_delete_at":null,
+    "force_delete_date":null,
     "statuses":[
       "ok"
     ],
@@ -295,7 +295,7 @@ Content-Type: application/json
   "pending_json":{
 
   },
-  "force_delete_at":null,
+  "force_delete_date":null,
   "statuses":[
     "ok"
   ],

--- a/doc/registrant-api/v1/registry_lock.md
+++ b/doc/registrant-api/v1/registry_lock.md
@@ -71,7 +71,7 @@ Content-Type: application/json
   "pending_json":{
 
   },
-  "force_delete_at":null,
+  "force_delete_date":null,
   "statuses":[
     "serverUpdateProhibited",
     "serverDeleteProhibited",
@@ -216,7 +216,7 @@ Content-Type: application/json
   "pending_json":{
 
   },
-  "force_delete_at":null,
+  "force_delete_date":null,
   "statuses":[
     "ok"
   ],

--- a/doc/repp/v1/domain.md
+++ b/doc/repp/v1/domain.md
@@ -57,7 +57,7 @@ Content-Type: application/json
       "registrant_verification_token": null,
       "pending_json": {
       },
-      "force_delete_at": null,
+      "force_delete_date": null,
       "statuses": [
         "ok"
       ],

--- a/lib/serializers/registrant_api/domain.rb
+++ b/lib/serializers/registrant_api/domain.rb
@@ -40,7 +40,7 @@ module Serializers
           registrant_verification_asked_at: domain.registrant_verification_asked_at,
           registrant_verification_token: domain.registrant_verification_token,
           pending_json: domain.pending_json,
-          force_delete_at: domain.force_delete_at,
+          force_delete_date: domain.force_delete_date,
           statuses: domain.statuses,
           locked_by_registrant_at: domain.locked_by_registrant_at,
           reserved: domain.reserved,

--- a/spec/presenters/domain_presenter_spec.rb
+++ b/spec/presenters/domain_presenter_spec.rb
@@ -63,16 +63,16 @@ RSpec.describe DomainPresenter do
     subject(:force_delete_date) { presenter.force_delete_date }
 
     context 'when present' do
-      let(:domain) { instance_double(Domain, force_delete_at: '05.07.2010') }
+      let(:domain) { instance_double(Domain, force_delete_date: '05.07.2010', force_delete_scheduled?: true) }
 
       it 'returns localized date' do
-        expect(view).to receive(:l).with('05.07.2010', format: :date).and_return('delete date')
+        expect(view).to receive(:l).with('05.07.2010').and_return('delete date')
         expect(force_delete_date).to eq('delete date')
       end
     end
 
     context 'when absent' do
-      let(:domain) { instance_double(Domain, force_delete_at: nil) }
+      let(:domain) { instance_double(Domain, force_delete_date: nil, force_delete_scheduled?: false) }
 
       specify { expect(force_delete_date).to be_nil }
     end

--- a/test/fixtures/domains.yml
+++ b/test/fixtures/domains.yml
@@ -8,7 +8,7 @@ shop:
   valid_to: <%= Time.zone.parse('2010-07-05').to_s(:db) %>
   outzone_at: <%= Time.zone.parse('2010-07-06').to_s(:db) %>
   delete_at: <%= Time.zone.parse('2010-07-07').to_s(:db) %>
-  force_delete_at: <%= Time.zone.parse('2010-07-08').to_s(:db) %>
+  force_delete_date: 2010-07-08
   period: 1
   period_unit: m
   uuid: 1b3ee442-e8fe-4922-9492-8fcb9dccc69c

--- a/test/lib/serializers/registrant_api/domain_test.rb
+++ b/test/lib/serializers/registrant_api/domain_test.rb
@@ -73,7 +73,7 @@ class SerializersRegistrantApiDomainTest < ActiveSupport::TestCase
               registrant tech_contacts admin_contacts transfer_code name_dirty name_puny period
               period_unit creator_str updator_str legacy_id legacy_registrar_id legacy_registrant_id
               outzone_at delete_at registrant_verification_asked_at
-              registrant_verification_token pending_json force_delete_at statuses
+              registrant_verification_token pending_json force_delete_date statuses
               locked_by_registrant_at reserved status_notes nameservers]
 
     assert_equal(keys, @json.keys & keys)

--- a/test/models/domain/releasable/auctionable_test.rb
+++ b/test/models/domain/releasable/auctionable_test.rb
@@ -40,6 +40,15 @@ class DomainReleasableAuctionableTest < ActiveSupport::TestCase
     assert_not @domain.domain_name.at_auction?
   end
 
+  def test_sells_domains_with_scheduled_force_delete_procedure_at_auction
+    @domain.update!(force_delete_date: '2010-07-05')
+    travel_to Time.zone.parse('2010-07-05')
+
+    Domain.release_domains
+
+    assert @domain.domain_name.at_auction?
+  end
+
   def test_deletes_registered_domain
     @domain.update!(delete_at: Time.zone.parse('2010-07-05 07:59'))
     travel_to Time.zone.parse('2010-07-05 08:00')

--- a/test/models/domain/releasable/discardable_test.rb
+++ b/test/models/domain/releasable/discardable_test.rb
@@ -15,6 +15,16 @@ class DomainReleasableDiscardableTest < ActiveSupport::TestCase
     assert @domain.discarded?
   end
 
+  def test_discards_domains_with_scheduled_force_delete_procedure
+    @domain.update!(force_delete_date: '2010-07-05')
+    travel_to Time.zone.parse('2010-07-05')
+
+    Domain.release_domains
+    @domain.reload
+
+    assert @domain.discarded?
+  end
+
   def test_ignores_domains_with_delete_at_in_the_future_or_now
     @domain.update!(delete_at: Time.zone.parse('2010-07-05 08:00'))
     travel_to Time.zone.parse('2010-07-05 08:00')

--- a/test/system/registrant_area/domains/details_test.rb
+++ b/test/system/registrant_area/domains/details_test.rb
@@ -7,7 +7,10 @@ class RegistrantAreaDomainDetailsTest < ApplicationSystemTestCase
   end
 
   def test_general_data
+    @domain.update_columns(force_delete_date: '2010-07-08', statuses: [DomainStatus::FORCE_DELETE])
+
     visit registrant_domain_url(@domain)
+
     assert_text 'Name shop.test'
     assert_text "Registered at #{l Time.zone.parse('2010-07-04')}"
     assert_link 'Best Names', href: registrant_registrar_path(@domain.registrar)
@@ -18,7 +21,7 @@ class RegistrantAreaDomainDetailsTest < ApplicationSystemTestCase
     assert_text "Valid to #{l Time.zone.parse('2010-07-05')}"
     assert_text "Outzone at #{l Time.zone.parse('2010-07-06')}"
     assert_text "Delete at #{l Time.zone.parse('2010-07-07')}"
-    assert_text "Force delete at #{l Time.zone.parse('2010-07-08')}"
+    assert_text "Force delete date #{l Date.parse('2010-07-08')}"
   end
 
   def test_registrant


### PR DESCRIPTION
- Change `domains.force_delete_at` database column type to date,
rename to `force_delete_date`
- Save `force_delete_date` in application timezone
- `DomainCron.destroy_delete_candidates` runner is removed from
`config/schedule.rb` with `domains:release` rake task as a replacement
- Improve tests

Verify:
- `domains:release` rake task
- `force_delete_date` in WHOIS
- Updating domain statuses from Admin area, when a domain has `DomainStatus::SERVER_MANUAL_INZONE` status

Fixes #812, #253
Closes #1119