### PR TITLE
On status update, create WHOIS records for domains in auction

### DIFF
--- a/app/controllers/api/v1/auctions_controller.rb
+++ b/app/controllers/api/v1/auctions_controller.rb
@@ -53,7 +53,7 @@ module Api
 
       def update_whois_from_auction(auction)
         whois_record = Whois::Record.find_or_create_by(name: auction.domain) do |record|
-          record.body = {}
+          record.json = {}
         end
 
         whois_record.update_from_auction(auction)

--- a/app/controllers/api/v1/auctions_controller.rb
+++ b/app/controllers/api/v1/auctions_controller.rb
@@ -52,7 +52,10 @@ module Api
       end
 
       def update_whois_from_auction(auction)
-        whois_record = Whois::Record.find_by!(name: auction.domain)
+        whois_record = Whois::Record.find_or_create_by(name: auction.domain) do |record|
+          record.body = {}
+        end
+
         whois_record.update_from_auction(auction)
       end
     end

--- a/db/whois_schema.rb
+++ b/db/whois_schema.rb
@@ -41,7 +41,6 @@ ActiveRecord::Schema.define(version: 20181102124618) do
 
   create_table "whois_records", force: :cascade do |t|
     t.string   "name"
-    t.text     "body"
     t.json     "json"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/test/integration/api/v1/auctions/update_test.rb
+++ b/test/integration/api/v1/auctions/update_test.rb
@@ -98,6 +98,19 @@ class ApiV1AuctionUpdateTest < ActionDispatch::IntegrationTest
     assert_equal Time.zone.parse('2010-07-05 10:00'), @whois_record.updated_at
   end
 
+  def test_creates_whois_record_if_does_not_exist
+    travel_to Time.zone.parse('2010-07-05 10:00')
+    assert_equal 'auction.test', @auction.domain
+    @whois_record.delete
+
+    patch api_v1_auction_path(@auction.uuid), { status: Auction.statuses[:payment_received] }
+                                                .to_json, 'Content-Type' => Mime::JSON.to_s
+
+    new_whois_record = Whois::Record.find_by(name: @auction.domain)
+    assert_equal Time.zone.parse('2010-07-05 10:00'), new_whois_record.updated_at
+    assert_equal ['PendingRegistration'], new_whois_record.json['status']
+  end
+
   def test_inaccessible_when_ip_address_is_not_allowed
     ENV['auction_api_allowed_ips'] = ''
 


### PR DESCRIPTION
Fixes #1133.

Steps to test:
- Release a domain to auction
- Remove whois record associated with that domain from database
- Finish auction and trigger status update from auction center.

A new whois record should be created for the domain.