### PR TITLE
Revamp `action_mailer` config

### DIFF
--- a/config/application-example.yml
+++ b/config/application-example.yml
@@ -21,7 +21,6 @@ smtp_openssl_verify_mode: 'peer' # 'none', 'peer', 'client_once','fail_if_no_pee
 smtp_enable_starttls_auto: 'true' # 'false'
 # If your mail server requires authentication, please change.
 smtp_authentication: 'plain' # 'plain', 'login', 'cram_md5'
-registrant_url: 'https://registrant.example.com' # for valid email body registrant links
 
 #
 # ADMIN server
@@ -143,12 +142,17 @@ same_site_session_cookies: 'false' # false|strict|lax
 release_domains_to_auction: 'true'
 auction_api_allowed_ips: '' # 192.0.2.0, 192.0.2.1
 
+action_mailer_default_protocol: # default: http
+action_mailer_default_host:
+action_mailer_default_port: # default: no port (80)
+
 # Since the keys for staging are absent from the repo, we need to supply them separate for testing.
 test:
   payments_seb_bank_certificate: 'test/fixtures/files/seb_bank_cert.pem'
   payments_seb_seller_private: 'test/fixtures/files/seb_seller_key.pem'
   release_domains_to_auction: 'false'
   auction_api_allowed_ips: ''
+  action_mailer_default_host: 'registry.test'
 
 # Airbrake // Errbit:
 airbrake_host: "https://your-errbit-host.ee"

--- a/config/application.rb
+++ b/config/application.rb
@@ -69,9 +69,9 @@ module DomainNameRegistry
       g.test_framework nil
     end
 
-    registrant_portal_uri = URI.parse(ENV['registrant_url'])
-    config.action_mailer.default_url_options = { host: registrant_portal_uri.host,
-                                                 protocol: registrant_portal_uri.scheme }
+    config.action_mailer.default_url_options = { protocol: ENV['action_mailer_default_protocol'],
+                                                 host: ENV['action_mailer_default_host'],
+                                                 port: ENV['action_mailer_default_port'] }
 
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.perform_deliveries = true

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -11,4 +11,5 @@ Figaro.require_keys(%w[
   legal_documents_dir
   bank_statement_import_dir
   time_zone
+  action_mailer_default_host
 ])


### PR DESCRIPTION
`registrant_url` setting in `application.yml` was misnamed. In fact, it had nothing to do with Registrant Portal. The intention is to provide default URL options for `action_mailer`, therefore `registrant_url` is removed, and new settings are introduced instead:

- `action_mailer_default_protocol`
- `action_mailer_default_host`
- `action_mailer_default_port`

@vohmar 
Verify links in emails. The settings above affect what protocol, host and port is used.

@ratM1n 
This change should fix the problem you had on staging. Previously `port` part of URL was ignored. Now there is a separate setting for this.

Note that `action_mailer_default_host` is required, whereas the rest is optional.