### PR TITLE
Do not send notification email if a contact does not act as a registrant on EPP contact:update

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -548,4 +548,8 @@ class Contact < ActiveRecord::Base
   def managed_by?(registrant_user)
     ident == registrant_user.ident
   end
+
+  def registrant?
+    registrant_domains.any?
+  end
 end

--- a/app/models/epp/contact.rb
+++ b/app/models/epp/contact.rb
@@ -179,7 +179,7 @@ class Epp::Contact < Contact
     old_email = email_was
     updated = save
 
-    if updated && email_changed
+    if updated && email_changed && registrant?
       ContactMailer.email_changed(contact: self, old_email: old_email).deliver_now
     end
 

--- a/test/integration/epp/contact/update/base_test.rb
+++ b/test/integration/epp/contact/update/base_test.rb
@@ -50,7 +50,7 @@ class EppContactUpdateBaseTest < ActionDispatch::IntegrationTest
 
   def test_notifies_contact_by_email_when_email_is_changed
     assert_equal 'john-001', @contact.code
-    assert_not_equal 'new@inbox.test', @contact.email
+    assert_not_equal 'john-new@inbox.test', @contact.email
 
     # https://github.com/internetee/registry/issues/415
     @contact.update_columns(code: @contact.code.upcase)
@@ -63,7 +63,7 @@ class EppContactUpdateBaseTest < ActionDispatch::IntegrationTest
             <contact:update xmlns:contact="https://epp.tld.ee/schema/contact-ee-1.1.xsd">
               <contact:id>john-001</contact:id>
               <contact:chg>
-                <contact:email>new@inbox.test</contact:email>
+                <contact:email>john-new@inbox.test</contact:email>
               </contact:chg>
             </contact:update>
           </update>
@@ -104,6 +104,37 @@ class EppContactUpdateBaseTest < ActionDispatch::IntegrationTest
     assert_no_emails
   end
 
+  def test_skips_notifying_a_contact_when_a_contact_is_not_a_registrant
+    assert_equal 'john-001', @contact.code
+    assert_not_equal 'john-new@inbox.test', @contact.email
+
+    make_contact_free_of_domains_where_it_acts_as_a_registrant(@contact)
+    assert_not @contact.registrant?
+
+    # https://github.com/internetee/registry/issues/415
+    @contact.update_columns(code: @contact.code.upcase)
+
+    request_xml = <<-XML
+      <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+      <epp xmlns="https://epp.tld.ee/schema/epp-ee-1.0.xsd">
+        <command>
+          <update>
+            <contact:update xmlns:contact="https://epp.tld.ee/schema/contact-ee-1.1.xsd">
+              <contact:id>john-001</contact:id>
+              <contact:chg>
+                <contact:email>john-new@inbox.test</contact:email>
+              </contact:chg>
+            </contact:update>
+          </update>
+        </command>
+      </epp>
+    XML
+
+    post '/epp/command/update', { frame: request_xml }, 'HTTP_COOKIE' => 'session=api_bestnames'
+
+    assert_no_emails
+  end
+
   def test_non_existing_contact
     assert_nil Contact.find_by(code: 'non-existing')
 
@@ -129,5 +160,13 @@ class EppContactUpdateBaseTest < ActionDispatch::IntegrationTest
 
     response_xml = Nokogiri::XML(response.body)
     assert_equal '2303', response_xml.at_css('result')[:code]
+  end
+
+  private
+
+  def make_contact_free_of_domains_where_it_acts_as_a_registrant(contact)
+    other_contact = contacts(:william)
+    assert_not_equal other_contact, contact
+    Domain.update_all(registrant_id: other_contact)
   end
 end

--- a/test/models/contact_test.rb
+++ b/test/models/contact_test.rb
@@ -79,4 +79,20 @@ class ContactTest < ActiveSupport::TestCase
       assert_equal [@contact], Contact.registrant_user_contacts(registrant_user)
     end
   end
+
+  def test_contact_is_a_registrant
+    assert_equal @contact.becomes(Registrant), domains(:shop).registrant
+    assert @contact.registrant?
+
+    make_contact_free_of_domains_where_it_acts_as_a_registrant(@contact)
+    assert_not @contact.registrant?
+  end
+
+  private
+
+  def make_contact_free_of_domains_where_it_acts_as_a_registrant(contact)
+    other_contact = contacts(:william)
+    assert_not_equal other_contact, contact
+    Domain.update_all(registrant_id: other_contact)
+  end
 end


### PR DESCRIPTION
Based on https://github.com/internetee/registry/pull/1160.

Fixes:
- Bug, when an email is sent if contact update fails under some circumstances
- #1161

Verify EPP `contact:update`