### PR TITLE
Remove hardcoded default email sender

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
   append_view_path Rails.root.join('app', 'views', 'mailers')
-  default from: 'noreply@internet.ee'
   layout 'mailer'
 
   # turn on delivery on specific (epp) request only, thus rake tasks does not deliver anything

--- a/config/application-example.yml
+++ b/config/application-example.yml
@@ -145,6 +145,7 @@ auction_api_allowed_ips: '' # 192.0.2.0, 192.0.2.1
 action_mailer_default_protocol: # default: http
 action_mailer_default_host:
 action_mailer_default_port: # default: no port (80)
+action_mailer_default_from: # no-reply@example.com
 
 # Since the keys for staging are absent from the repo, we need to supply them separate for testing.
 test:
@@ -153,6 +154,7 @@ test:
   release_domains_to_auction: 'false'
   auction_api_allowed_ips: ''
   action_mailer_default_host: 'registry.test'
+  action_mailer_default_from: 'no-reply@registry.test'
 
 # Airbrake // Errbit:
 airbrake_host: "https://your-errbit-host.ee"

--- a/config/application.rb
+++ b/config/application.rb
@@ -90,6 +90,7 @@ module DomainNameRegistry
       domain:               ENV['smtp_domain'],
       openssl_verify_mode:  ENV['smtp_openssl_verify_mode']
     }
+    config.action_mailer.default_options = { from: ENV['action_mailer_default_from'] }
 
     config.action_view.default_form_builder = 'DefaultFormBuilder'
     config.secret_key_base = Figaro.env.secret_key_base

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -12,4 +12,5 @@ Figaro.require_keys(%w[
   bank_statement_import_dir
   time_zone
   action_mailer_default_host
+  action_mailer_default_from
 ])

--- a/test/mailers/application_mailer_test.rb
+++ b/test/mailers/application_mailer_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class ApplicationMailerTest < ActiveSupport::TestCase
+  def test_reads_default_from_setting_from_config
+    assert_equal 'no-reply@registry.test', ENV['action_mailer_default_from']
+
+    mailer = Class.new(ApplicationMailer) do
+      def test
+        # Empty block to avoid template rendering
+        mail {}
+      end
+    end
+    email = mailer.test
+
+    assert_equal ['no-reply@registry.test'], email.from
+  end
+end


### PR DESCRIPTION
Remove hardcoded default email sender and make it configurable via `action_mailer_default_from` config.

@ratM1n Should be set to `noreply@internet.ee` in prod.

Closes #243