### PR TITLE
Remove unused columns from `log_domains` database table

### DIFF
--- a/app/models/legal_document.rb
+++ b/app/models/legal_document.rb
@@ -87,8 +87,7 @@ class LegalDocument < ActiveRecord::Base
 
       contact_ids = DomainVersion.where(item_id: orig_legal.documentable_id).distinct.
           pluck("object->>'registrant_id'", "object_changes->>'registrant_id'",
-                "children->>'tech_contacts'", "children->>'admin_contacts'",
-                "tech_contact_ids", "admin_contact_ids").flatten.uniq
+                "children->>'tech_contacts'", "children->>'admin_contacts'").flatten.uniq
       contact_ids = contact_ids.map{|id|
         case id
           when Hash

--- a/db/migrate/20190415120246_remove_unused_columns_from_log_domains.rb
+++ b/db/migrate/20190415120246_remove_unused_columns_from_log_domains.rb
@@ -1,0 +1,7 @@
+class RemoveUnusedColumnsFromLogDomains < ActiveRecord::Migration
+  def change
+    remove_column :log_domains, :nameserver_ids
+    remove_column :log_domains, :admin_contact_ids
+    remove_column :log_domains, :tech_contact_ids
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1539,9 +1539,6 @@ CREATE TABLE public.log_domains (
     object jsonb,
     object_changes json,
     created_at timestamp without time zone,
-    nameserver_ids text[] DEFAULT '{}'::text[],
-    tech_contact_ids text[] DEFAULT '{}'::text[],
-    admin_contact_ids text[] DEFAULT '{}'::text[],
     session character varying,
     children json,
     uuid character varying
@@ -4939,4 +4936,6 @@ INSERT INTO schema_migrations (version) VALUES ('20190319133036');
 INSERT INTO schema_migrations (version) VALUES ('20190322152123');
 
 INSERT INTO schema_migrations (version) VALUES ('20190322152529');
+
+INSERT INTO schema_migrations (version) VALUES ('20190415120246');
 

--- a/test/system/admin_area/domain_versions_test.rb
+++ b/test/system/admin_area/domain_versions_test.rb
@@ -29,12 +29,11 @@ class DomainVersionsTest < ApplicationSystemTestCase
       VALUES (54, 54, '2018-06-23T12:14:02.732+03:00', 54, 'transfer_code');
 
       INSERT INTO log_domains (item_type, item_id, event, whodunnit, object,
-      object_changes, created_at, nameserver_ids, tech_contact_ids,
-      admin_contact_ids, session, children)
+      object_changes, created_at, session, children)
       VALUES ('Domain', 54, 'update', '1-AdminUser',
       '{"id": 54, "registrar_id": 54, "valid_to": "2018-07-23T12:14:05.583+03:00", "registrant_id": 54, "transfer_code": "transfer_code", "valid_from": "2017-07-23T12:14:05.583+03:00"}',
       '{"foo": "bar", "other_made_up_field": "value"}',
-      '2018-04-23 15:50:48.113491', '{}', '{}', '{}', '2018-04-23 12:44:56',
+      '2018-04-23 15:50:48.113491', '2018-04-23 12:44:56',
       '{"null_fracdmin_contacts":[108],"tech_contacts":[109],"nameservers":[],"dnskeys":[],"legal_documents":[null],"registrant":[1]}'
       )
     SQL


### PR DESCRIPTION
Removes `nameserver_ids`, `admin_contact_ids` and `tech_contact_ids` from `log_domains`.

@ratM1n has confirmed, that there are no records with value other than `{}` in prod.

Verify `legal_doc.remove_duplicates` task.