### PR TITLE
Add custom `From` header for "force delete" email

### DIFF
--- a/app/mailers/domain_delete_mailer.rb
+++ b/app/mailers/domain_delete_mailer.rb
@@ -41,7 +41,8 @@ class DomainDeleteMailer < ApplicationMailer
     @redemption_grace_period = Setting.redemption_grace_period
 
     subject = default_i18n_subject(domain_name: domain.name)
-    mail(to: domain.primary_contact_emails,
+    mail(from: forced_email_from,
+         to: domain.primary_contact_emails,
          subject: subject,
          template_path: 'mailers/domain_delete_mailer/forced',
          template_name: template_name)
@@ -51,5 +52,9 @@ class DomainDeleteMailer < ApplicationMailer
 
   def confirmation_url(domain)
     registrant_domain_delete_confirm_url(domain, token: domain.registrant_verification_token)
+  end
+
+  def forced_email_from
+    ENV['action_mailer_force_delete_from'] || self.class.default[:from]
   end
 end

--- a/config/application-example.yml
+++ b/config/application-example.yml
@@ -146,6 +146,7 @@ action_mailer_default_protocol: # default: http
 action_mailer_default_host:
 action_mailer_default_port: # default: no port (80)
 action_mailer_default_from: # no-reply@example.com
+action_mailer_force_delete_from: # `From` header for `DomainDeleteMailer#forced` email
 
 # Since the keys for staging are absent from the repo, we need to supply them separate for testing.
 test:
@@ -155,6 +156,7 @@ test:
   auction_api_allowed_ips: ''
   action_mailer_default_host: 'registry.test'
   action_mailer_default_from: 'no-reply@registry.test'
+  action_mailer_force_delete_from: 'legal@registry.test'
 
 # Airbrake // Errbit:
 airbrake_host: "https://your-errbit-host.ee"

--- a/test/mailers/domain_delete_mailer_test.rb
+++ b/test/mailers/domain_delete_mailer_test.rb
@@ -66,6 +66,7 @@ class DomainDeleteMailerTest < ActiveSupport::TestCase
     assert_equal 'shop.test', @domain.name
     assert_equal 'john@inbox.test', @domain.registrant.email
     assert_equal 'jane@mail.test', @domain.admin_contacts.first.email
+    assert_equal 'legal@registry.test', ENV['action_mailer_force_delete_from']
 
     email = DomainDeleteMailer.forced(domain: @domain,
                                       registrar: @domain.registrar,
@@ -74,6 +75,7 @@ class DomainDeleteMailerTest < ActiveSupport::TestCase
                                                        .first).deliver_now
 
     assert_emails 1
+    assert_equal ['legal@registry.test'], email.from
     assert_equal %w[jane@mail.test john@inbox.test], email.to
     assert_equal 'Domeen shop.test on kustutusmenetluses' \
                  ' / Domain shop.test is in deletion process' \


### PR DESCRIPTION
New config: `action_mailer_force_delete_from`

Closes #1164