### PR TITLE
Populate invoice VAT rate

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -38,7 +38,6 @@ class Invoice < ActiveRecord::Base
   before_create :apply_default_buyer_vat_no, unless: :buyer_vat_no?
 
   attribute :vat_rate, ::Type::VATRate.new
-  attr_readonly :vat_rate
 
   def set_invoice_number
     last_no = Invoice.order(number: :desc).where('number IS NOT NULL').limit(1).pluck(:number).first

--- a/lib/tasks/data_migrations/populate_invoice_vat_rate.rake
+++ b/lib/tasks/data_migrations/populate_invoice_vat_rate.rake
@@ -1,0 +1,14 @@
+namespace :data_migrations do
+  task populate_invoice_vat_rate: :environment do
+    processed_invoice_count = 0
+
+    Invoice.transaction do
+      Invoice.where(vat_rate: nil).find_each do |invoice|
+        invoice.update_columns(vat_rate: invoice.buyer.effective_vat_rate)
+        processed_invoice_count += 1
+      end
+    end
+
+    puts "Invoices processed: #{processed_invoice_count}"
+  end
+end

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -58,12 +58,10 @@ class InvoiceTest < ActiveSupport::TestCase
   end
 
   def test_serializes_and_deserializes_vat_rate
-    invoice = @invoice.dup
-    invoice.items = @invoice.items
-    invoice.vat_rate = BigDecimal('25.5')
-    invoice.save!
-    invoice.reload
-    assert_equal BigDecimal('25.5'), invoice.vat_rate
+    @invoice.vat_rate = BigDecimal('25.5')
+    @invoice.save!
+    @invoice.reload
+    assert_equal BigDecimal('25.5'), @invoice.vat_rate
   end
 
   def test_vat_rate_defaults_to_effective_vat_rate_of_a_registrar
@@ -78,13 +76,6 @@ class InvoiceTest < ActiveSupport::TestCase
     end
 
     assert_equal BigDecimal(55), invoice.vat_rate
-  end
-
-  def test_vat_rate_cannot_be_updated
-    @invoice.vat_rate = BigDecimal(21)
-    @invoice.save!
-    @invoice.reload
-    refute_equal BigDecimal(21), @invoice.vat_rate
   end
 
   def test_calculates_vat_amount

--- a/test/tasks/data_migrations/populate_invoice_vat_rate_test.rb
+++ b/test/tasks/data_migrations/populate_invoice_vat_rate_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class PopulateInvoiceVatRateTaskTest < ActiveSupport::TestCase
+  setup do
+    @invoice = invoices(:one)
+  end
+
+  def test_populates_invoice_issue_date
+    eliminate_effect_of_all_invoices_except(@invoice)
+    @invoice.update_columns(vat_rate: nil)
+
+    capture_io do
+      run_task
+    end
+    @invoice.reload
+
+    assert_not_nil @invoice.vat_rate
+  end
+
+  def test_output
+    eliminate_effect_of_all_invoices_except(@invoice)
+    @invoice.update_columns(vat_rate: nil)
+
+    assert_output "Invoices processed: 1\n" do
+      run_task
+    end
+  end
+
+  private
+
+  def eliminate_effect_of_all_invoices_except(invoice)
+    Invoice.connection.disable_referential_integrity do
+      Invoice.delete_all("id != #{invoice.id}")
+    end
+  end
+
+  def run_task
+    Rake::Task['data_migrations:populate_invoice_vat_rate'].execute
+  end
+end


### PR DESCRIPTION
Deploy before and separately from #1031.

To deploy run `data_migrations:populate_invoice_vat_rate` task.