### PR TITLE
Remove `html5_validators` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,6 @@ gem 'selectize-rails', '0.12.1' # include selectize.js for select
 # view helpers
 gem 'kaminari',         '0.16.3'  # pagination
 gem 'coderay',          '1.1.0'   # xml console visualize
-gem 'html5_validators', '1.2.2'   # model requements now automatically on html form
 gem 'select2-rails',    '3.5.9.3' # for autocomplete
 gem 'liquid',           '3.0.6'   # for email templates
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,6 @@ GEM
       haml (~> 4.0)
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
-    html5_validators (1.2.2)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.8.3)
@@ -467,7 +466,6 @@ DEPENDENCIES
   grape
   haml-rails (= 0.9.0)
   html2haml (= 2.1.0)
-  html5_validators (= 1.2.2)
   isikukood
   iso8601 (= 0.8.6)
   jbuilder (= 2.2.16)

--- a/app/models/billing/price.rb
+++ b/app/models/billing/price.rb
@@ -2,8 +2,6 @@ module Billing
   class Price < ActiveRecord::Base
     include Concerns::Billing::Price::Expirable
 
-    self.auto_html5_validation = false
-
     belongs_to :zone, class_name: 'DNS::Zone', required: true
     has_many :account_activities
 

--- a/app/models/concerns/disable_html5_validation.rb
+++ b/app/models/concerns/disable_html5_validation.rb
@@ -1,9 +1,0 @@
-module DisableHtml5Validation
-  extend ActiveSupport::Concern
-
-  class_methods do
-    def auto_html5_validation
-      false
-    end
-  end
-end

--- a/app/models/deposit.rb
+++ b/app/models/deposit.rb
@@ -2,7 +2,6 @@ class Deposit
   include ActiveModel::Validations
   include ActiveModel::Conversion
   extend ActiveModel::Naming
-  include DisableHtml5Validation
 
   attr_accessor :description, :registrar, :registrar_id
   attr_writer :amount

--- a/app/models/depp/contact.rb
+++ b/app/models/depp/contact.rb
@@ -1,7 +1,6 @@
 module Depp
   class Contact
     include ActiveModel::Model
-    include DisableHtml5Validation
 
     attr_accessor :id, :name, :email, :phone, :org_name,
       :ident, :ident_type, :ident_country_code,

--- a/app/models/depp/domain.rb
+++ b/app/models/depp/domain.rb
@@ -2,7 +2,6 @@ module Depp
   class Domain
     include ActiveModel::Conversion
     extend ActiveModel::Naming
-    include DisableHtml5Validation
 
     attr_accessor :name, :current_user, :epp_xml
 

--- a/app/models/depp/keyrelay.rb
+++ b/app/models/depp/keyrelay.rb
@@ -1,6 +1,5 @@
 module Depp
   class Keyrelay
-    include DisableHtml5Validation
     attr_accessor :current_user, :epp_xml
 
     def initialize(args = {})

--- a/app/models/depp/user.rb
+++ b/app/models/depp/user.rb
@@ -3,7 +3,6 @@ module Depp
     include ActiveModel::Validations
     include ActiveModel::Conversion
     extend ActiveModel::Naming
-    include DisableHtml5Validation
 
     attr_accessor :tag, :password, :pki
 

--- a/app/models/dns/zone.rb
+++ b/app/models/dns/zone.rb
@@ -1,7 +1,5 @@
 module DNS
   class Zone < ActiveRecord::Base
-    self.auto_html5_validation = false
-
     validates :origin, :ttl, :refresh, :retry, :expire, :minimum_ttl, :email, :master_nameserver, presence: true
     validates :ttl, :refresh, :retry, :expire, :minimum_ttl, numericality: { only_integer: true }
     validates :origin, uniqueness: true

--- a/app/views/registrant/sessions/login_mid.haml
+++ b/app/views/registrant/sessions/login_mid.haml
@@ -2,8 +2,7 @@
   .form-signin.col-md-4.center-block.text-center
     %h2.form-signin-heading.text-center= t '.header'
     %hr
-    = form_for @user, url: registrant_mid_path, auto_html5_validation: false, 
-      html: {class: 'form-signin'} do |f|
+    = form_for @user, url: registrant_mid_path, html: {class: 'form-signin'} do |f|
       = f.text_field :phone, class: 'form-control', 
         placeholder: t(:phone_no), autocomplete: 'off', required: true
       %button.btn.btn-lg.btn-primary.btn-block.js-login{:type => 'submit'}= t '.submit_btn'

--- a/app/views/registrar/sessions/login_mid.haml
+++ b/app/views/registrar/sessions/login_mid.haml
@@ -2,8 +2,7 @@
   .form-signin.col-md-4.center-block.text-center
     %h2.form-signin-heading.text-center= t '.header'
     %hr
-    = form_for @user, url: registrar_mid_path, auto_html5_validation: false,
-      html: {class: 'form-signin'} do |f|
+    = form_for @user, url: registrar_mid_path, html: {class: 'form-signin'} do |f|
       = f.text_field :phone, class: 'form-control',
         placeholder: t(:phone_no), autocomplete: 'off', required: true
       %button.btn.btn-lg.btn-primary.btn-block.js-login{:type => 'submit'}= t '.submit_btn'


### PR DESCRIPTION
I lost the count how many times I stumbled upon the issues connected to this gem, so I am removing it now.

This change applies to all areas and only affects front-end validation.

@vohmar The only thing you can to to verify front-end validation on the most important forms. this gem is full of magic, so I can't predict what exactly can go wrong. Definitely check for `presence` validation. I think the rest in not so important.

Closes #367