### PR TITLE
Notify registrar about domain deletion when auction feature is on

### DIFF
--- a/app/models/concerns/domain/releasable.rb
+++ b/app/models/concerns/domain/releasable.rb
@@ -42,6 +42,9 @@ module Concerns
           transaction do
             domain_name.sell_at_auction if domain_name.auctionable?
             destroy!
+            registrar.notifications.create!(text: "#{I18n.t(:domain_deleted)}: #{name}",
+                                            attached_obj_id: id,
+                                            attached_obj_type: self.class)
           end
         else
           discard

--- a/test/models/domain/releasable/auctionable_test.rb
+++ b/test/models/domain/releasable/auctionable_test.rb
@@ -58,6 +58,15 @@ class DomainReleasableAuctionableTest < ActiveSupport::TestCase
     end
   end
 
+  def test_notifies_registrar
+    @domain.update!(delete_date: '2010-07-04')
+    travel_to Time.zone.parse('2010-07-05')
+
+    assert_difference -> { @domain.registrar.notifications.count } do
+      Domain.release_domains
+    end
+  end
+
   def test_ignores_domains_with_delete_date_in_the_future
     @domain.update!(delete_date: '2010-07-06')
     travel_to Time.zone.parse('2010-07-05')


### PR DESCRIPTION
This is a quick fix for #1196. 

Proper fix should be done separately https://github.com/internetee/registry/issues/1198 during next month.

Fixes #1196