### PR TITLE
Validate registrar's billing email

### DIFF
--- a/app/models/registrar.rb
+++ b/app/models/registrar.rb
@@ -32,9 +32,9 @@ class Registrar < ActiveRecord::Base
   attribute :vat_rate, ::Type::VATRate.new
   after_initialize :set_defaults
 
-  validates :email, :billing_email,
-    email_format: { message: :invalid },
-    allow_blank: true, if: proc { |c| c.email_changed? }
+  validates :email, email_format: { message: :invalid },
+            allow_blank: true, if: proc { |c| c.email_changed? }
+  validates :billing_email, email_format: { message: :invalid }, allow_blank: true
 
   WHOIS_TRIGGERS = %w(name email phone street city state zip)
 

--- a/test/models/registrar_test.rb
+++ b/test/models/registrar_test.rb
@@ -37,6 +37,22 @@ class RegistrarTest < ActiveSupport::TestCase
     assert registrar.invalid?
   end
 
+  def test_optional_billing_email
+    registrar = valid_registrar
+    registrar.billing_email = ''
+    assert registrar.valid?
+  end
+
+  def test_billing_email_format_validation
+    registrar = valid_registrar
+
+    registrar.billing_email = 'invalid'
+    assert registrar.invalid?
+
+    registrar.billing_email = 'valid@email.test'
+    assert registrar.valid?
+  end
+
   def test_invalid_without_language
     registrar = valid_registrar
     registrar.language = ''


### PR DESCRIPTION
Previously it was being validated only if contact email changed (contact
and billing emails have nothing in common).