### PR TITLE
remove figaro requires what are not common to all apps

### DIFF
--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -1,15 +1,7 @@
 Figaro.require_keys(%w[
   app_name
-  zonefile_export_dir
   secret_key_base
   devise_secret
-  crl_dir
-  ca_cert_path
-  ca_key_path
-  ca_key_password
-  webclient_ips
-  legal_documents_dir
-  bank_statement_import_dir
   time_zone
   action_mailer_default_host
   action_mailer_default_from


### PR DESCRIPTION
Only Admin/Registry use these parameters.
Removing them so they can be unset in registrar/registrant/epp

Noting to test.