### PR TITLE
Upgrade bundler and extend travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: ruby
+rvm:
+  - 2.4
+  - 2.5
+  - 2.6
 cache: bundler
 env:
   - DB=postgresql
@@ -10,6 +14,7 @@ before_install:
   - "sudo mv -f ~/chromedriver /usr/local/share/"
   - "sudo chmod +x /usr/local/share/chromedriver"
   - "sudo ln -s /usr/local/share/chromedriver /usr/local/bin/chromedriver"
+  - "gem update --system"
   - "gem install bundler"
 before_script:
   - "cp config/application-example.yml config/application.yml"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - "sudo chmod +x /usr/local/share/chromedriver"
   - "sudo ln -s /usr/local/share/chromedriver /usr/local/bin/chromedriver"
   - "gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true"
-  - "gem install bundler -v '< 2'"
+  - "gem install bundler"
 before_script:
   - "cp config/application-example.yml config/application.yml"
   - "cp config/database-travis.yml config/database.yml"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ before_install:
   - "sudo mv -f ~/chromedriver /usr/local/share/"
   - "sudo chmod +x /usr/local/share/chromedriver"
   - "sudo ln -s /usr/local/share/chromedriver /usr/local/bin/chromedriver"
-  - "gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true"
   - "gem install bundler"
 before_script:
   - "cp config/application-example.yml config/application.yml"

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,3 @@
-# Use https only for accessing github
-# https://github.com/bundler/bundler/pull/3447
-git_source(:github) do |repo_name|
-  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
-  "https://github.com/#{repo_name}.git"
-end if Bundler::VERSION < '2'
-
 source 'https://rubygems.org'
 
 # core

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -520,4 +520,4 @@ DEPENDENCIES
   whenever (= 0.9.4)
 
 BUNDLED WITH
-   1.17.3
+   2.0.2


### PR DESCRIPTION
Use bundler version 2.x and  improve travis configuration
Closes #1078 .

Seems to work in staging but should be deployed with caution ( registrant portal  first for example ) 