### PR TITLE
Revert "Upgrade bundler and extend travis"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 language: ruby
-rvm:
-  - 2.4
-  - 2.5
-  - 2.6
 cache: bundler
 env:
   - DB=postgresql
@@ -14,8 +10,8 @@ before_install:
   - "sudo mv -f ~/chromedriver /usr/local/share/"
   - "sudo chmod +x /usr/local/share/chromedriver"
   - "sudo ln -s /usr/local/share/chromedriver /usr/local/bin/chromedriver"
-  - "gem update --system"
-  - "gem install bundler"
+  - "gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true"
+  - "gem install bundler -v '< 2'"
 before_script:
   - "cp config/application-example.yml config/application.yml"
   - "cp config/database-travis.yml config/database.yml"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,10 @@
+# Use https only for accessing github
+# https://github.com/bundler/bundler/pull/3447
+git_source(:github) do |repo_name|
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+  "https://github.com/#{repo_name}.git"
+end if Bundler::VERSION < '2'
+
 source 'https://rubygems.org'
 
 # core

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -520,4 +520,4 @@ DEPENDENCIES
   whenever (= 0.9.4)
 
 BUNDLED WITH
-   2.0.2
+   1.17.3


### PR DESCRIPTION
Reverts internetee/registry#1280
Opens #1078

Managing two bundler versions is too hard, have to revert untill we upgrade Rails