### PR TITLE
Update `hashdiff` gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,7 +208,7 @@ GEM
       haml (>= 4.0.6, < 5.0)
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
-    hashdiff (0.4.0)
+    hashdiff (1.0.0)
     hpricot (0.8.6)
     html2haml (2.1.0)
       erubis (~> 2.7.0)


### PR DESCRIPTION
Removes deprecation message

> The HashDiff constant used by this gem conflicts with another gem of a
similar name.  As of version 1.0 the HashDiff constant will be
completely removed and replaced by Hashdiff.  For more information see

https://github.com/liufengyun/hashdiff/issues/45.