### PR TITLE
Remove EPP response header

### DIFF
--- a/app/controllers/epp/sessions_controller.rb
+++ b/app/controllers/epp/sessions_controller.rb
@@ -82,7 +82,6 @@ class Epp::SessionsController < EppController
     if success
       if params[:parsed_frame].css('newPW').first
         unless @api_user.update(plain_text_password: params[:parsed_frame].css('newPW').first.text)
-          response.headers['X-EPP-Returncode'] = '2500'
           handle_errors(@api_user) and return
         end
       end
@@ -93,7 +92,6 @@ class Epp::SessionsController < EppController
       epp_session.save!
       render_epp_response('login_success')
     else
-      response.headers['X-EPP-Returncode'] = '2500'
       handle_errors
     end
   end
@@ -119,7 +117,6 @@ class Epp::SessionsController < EppController
 
     @api_user = current_user # cache current_user for logging
     epp_session.destroy
-    response.headers['X-EPP-Returncode'] = '1500'
     render_epp_response('logout')
   end
 

--- a/app/controllers/epp_controller.rb
+++ b/app/controllers/epp_controller.rb
@@ -22,7 +22,6 @@ class EppController < ApplicationController
         code: 2001,
         msg: error
       }
-      response.headers['X-EPP-Returncode'] = '2200'
     end
     handle_errors and return if epp_errors.any?
   end
@@ -375,7 +374,6 @@ class EppController < ApplicationController
     if session_timeout_reached?
       @api_user = current_user # cache current_user for logging
       epp_session.destroy
-      response.headers['X-EPP-Returncode'] = '1500'
 
       epp_errors << {
         msg: t('session_timeout'),


### PR DESCRIPTION
Remove `mod_epp`-specific `X-EPP-Returncode` header set in EPP response
since `mod_epp` was replaced by https://github.com/internetee/epp_proxy.