### PR TITLE
Remove unnecessary statement

### DIFF
--- a/app/controllers/epp_controller.rb
+++ b/app/controllers/epp_controller.rb
@@ -1,6 +1,5 @@
 class EppController < ApplicationController
   layout false
-  protect_from_forgery with: :null_session
   skip_before_action :verify_authenticity_token
 
   before_action :ensure_session_id_passed


### PR DESCRIPTION
CSRF protection makes no sense in EPP and is already disabled with
`skip_before_action :verify_authenticity_token`.