### PR TITLE
Fix EPP session timeout

### DIFF
--- a/app/controllers/epp/base_controller.rb
+++ b/app/controllers/epp/base_controller.rb
@@ -368,7 +368,7 @@ module Epp
     end
 
     def session_timeout_reached?
-      timeout = 5.minutes
+      timeout = ENV['epp_session_timeout_seconds'].to_i.seconds
       epp_session.updated_at < (Time.zone.now - timeout)
     end
 

--- a/app/controllers/epp/base_controller.rb
+++ b/app/controllers/epp/base_controller.rb
@@ -10,7 +10,8 @@ module Epp
     before_action :latin_only
     before_action :validate_against_schema
     before_action :validate_request
-    before_action :update_epp_session, if: -> { signed_in? }
+    before_action :enforce_epp_session_timeout, if: :signed_in?
+    before_action :iptables_counter_update, if: :signed_in?
 
     around_action :wrap_exceptions
 
@@ -349,32 +350,21 @@ module Epp
       raise 'EPP session id is empty' unless epp_session_id.present?
     end
 
-    def update_epp_session
-      iptables_counter_update
-
-      if session_timeout_reached?
-        @api_user = current_user # cache current_user for logging
-        epp_session.destroy
-
+    def enforce_epp_session_timeout
+      if epp_session.timed_out?
         epp_errors << {
-          msg: t('session_timeout'),
-          code: '2201'
+          code: '2201',
+          msg: 'Authorization error: Session timeout',
         }
-
-        handle_errors and return
+        handle_errors
+        epp_session.destroy!
       else
-        epp_session.update_column(:updated_at, Time.zone.now)
+        epp_session.update_last_access
       end
-    end
-
-    def session_timeout_reached?
-      timeout = ENV['epp_session_timeout_seconds'].to_i.seconds
-      epp_session.updated_at < (Time.zone.now - timeout)
     end
 
     def iptables_counter_update
       return if ENV['iptables_counter_enabled'].blank? && ENV['iptables_counter_enabled'] != 'true'
-      return if current_user.blank?
       counter_update(current_user.registrar_code, ENV['iptables_server_ip'])
     end
 

--- a/app/controllers/epp/base_controller.rb
+++ b/app/controllers/epp/base_controller.rb
@@ -365,6 +365,7 @@ module Epp
 
     def iptables_counter_update
       return if ENV['iptables_counter_enabled'].blank? && ENV['iptables_counter_enabled'] != 'true'
+
       counter_update(current_user.registrar_code, ENV['iptables_server_ip'])
     end
 

--- a/app/models/epp/expired_sessions.rb
+++ b/app/models/epp/expired_sessions.rb
@@ -1,0 +1,13 @@
+module Epp
+  class ExpiredSessions
+    attr_reader :sessions
+
+    def initialize(sessions)
+      @sessions = sessions
+    end
+
+    def clear
+      sessions.find_each(&:destroy!)
+    end
+  end
+end

--- a/app/models/epp_session.rb
+++ b/app/models/epp_session.rb
@@ -4,7 +4,7 @@ class EppSession < ApplicationRecord
   validates :session_id, uniqueness: true, presence: true
 
   class_attribute :timeout
-  self.timeout = ENV['epp_session_timeout_seconds'].to_i.seconds
+  self.timeout = (ENV['epp_session_timeout_seconds'] || 300).to_i.seconds
 
   alias_attribute :last_access, :updated_at
 

--- a/app/models/epp_session.rb
+++ b/app/models/epp_session.rb
@@ -3,6 +3,11 @@ class EppSession < ApplicationRecord
 
   validates :session_id, uniqueness: true, presence: true
 
+  class_attribute :timeout
+  self.timeout = ENV['epp_session_timeout_seconds'].to_i.seconds
+
+  alias_attribute :last_access, :updated_at
+
   def self.limit_per_registrar
     4
   end
@@ -10,5 +15,22 @@ class EppSession < ApplicationRecord
   def self.limit_reached?(registrar)
     count = where(user_id: registrar.api_users.ids).where('updated_at >= ?', Time.zone.now - 1.second).count
     count >= limit_per_registrar
+  end
+
+  def self.expired
+    interval = "#{timeout.parts.first.second} #{timeout.parts.first.first}"
+    where(':now > (updated_at + interval :interval)', now: Time.zone.now, interval: interval)
+  end
+
+  def update_last_access
+    touch
+  end
+
+  def timed_out?
+    (updated_at + self.class.timeout).past?
+  end
+
+  def expired?
+    timed_out?
   end
 end

--- a/config/application.yml.sample
+++ b/config/application.yml.sample
@@ -153,6 +153,8 @@ lhv_keystore_password:
 lhv_ca_file: # Needed only in dev mode
 lhv_dev_mode: 'false'
 
+epp_session_timeout_seconds: '300'
+
 # Since the keys for staging are absent from the repo, we need to supply them separate for testing.
 test:
   payments_seb_bank_certificate: 'test/fixtures/files/seb_bank_cert.pem'

--- a/lib/tasks/epp/clear_expired_sessions.rake
+++ b/lib/tasks/epp/clear_expired_sessions.rake
@@ -1,0 +1,7 @@
+namespace :epp do
+  desc 'Clear expired EPP sessions'
+
+  task clear_expired_sessions: :environment do
+    Epp::ExpiredSessions.new(EppSession.expired).clear
+  end
+end

--- a/test/integration/epp/base_test.rb
+++ b/test/integration/epp/base_test.rb
@@ -7,6 +7,14 @@ class DummyEppController < Epp::BaseController
 end
 
 class EppBaseTest < EppTestCase
+  setup do
+    @original_session_timeout = EppSession.timeout
+  end
+
+  teardown do
+    EppSession.timeout = @original_session_timeout
+  end
+
   def test_internal_error
     Rails.application.routes.draw do
       post 'epp/command/internal_error', to: 'dummy_epp#internal_error',
@@ -79,6 +87,62 @@ class EppBaseTest < EppTestCase
          headers: { 'HTTP_COOKIE' => "session=#{session.session_id}" }
 
     assert_epp_response :authorization_error
+  end
+
+  def test_deletes_session_when_timed_out
+    now = Time.zone.parse('2010-07-05')
+    travel_to now
+    timeout = 0.second
+    EppSession.timeout = timeout
+    session = epp_sessions(:api_bestnames)
+    session.update!(updated_at: now - timeout - 1.second)
+
+    authentication_enabled_epp_request_xml = <<-XML
+      <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+      <epp xmlns="https://epp.tld.ee/schema/epp-ee-1.0.xsd">
+        <command>
+          <info>
+            <domain:info xmlns:domain="https://epp.tld.ee/schema/domain-eis-1.0.xsd">
+              <domain:name>#{domains(:shop).name}</domain:name>
+            </domain:info>
+          </info>
+        </command>
+      </epp>
+    XML
+    post '/epp/command/info', { frame: authentication_enabled_epp_request_xml },
+         'HTTP_COOKIE' => "session=#{session.session_id}"
+
+    assert_epp_response :authorization_error
+    assert_nil EppSession.find_by(session_id: session.session_id)
+  end
+
+  def test_session_last_access_is_updated_when_not_timed_out
+    now = Time.zone.parse('2010-07-05')
+    travel_to now
+    timeout = 1.seconds
+    EppSession.timeout = timeout
+    session = epp_sessions(:api_bestnames)
+    session.last_access = now - timeout
+
+    authentication_enabled_epp_request_xml = <<-XML
+      <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+      <epp xmlns="https://epp.tld.ee/schema/epp-ee-1.0.xsd">
+        <command>
+          <info>
+            <domain:info xmlns:domain="https://epp.tld.ee/schema/domain-eis-1.0.xsd">
+              <domain:name>#{domains(:shop).name}</domain:name>
+            </domain:info>
+          </info>
+        </command>
+      </epp>
+    XML
+
+    post '/epp/command/info', { frame: authentication_enabled_epp_request_xml },
+         'HTTP_COOKIE' => "session=#{session.session_id}"
+    session.reload
+
+    assert_epp_response :completed_successfully
+    assert_equal now, session.last_access
   end
 
   private

--- a/test/integration/epp/base_test.rb
+++ b/test/integration/epp/base_test.rb
@@ -109,8 +109,8 @@ class EppBaseTest < EppTestCase
         </command>
       </epp>
     XML
-    post '/epp/command/info', { frame: authentication_enabled_epp_request_xml },
-         'HTTP_COOKIE' => "session=#{session.session_id}"
+    post '/epp/command/info', params: { frame: authentication_enabled_epp_request_xml },
+         headers: { 'HTTP_COOKIE' => "session=#{session.session_id}" }
 
     assert_epp_response :authorization_error
     assert_nil EppSession.find_by(session_id: session.session_id)
@@ -137,8 +137,9 @@ class EppBaseTest < EppTestCase
       </epp>
     XML
 
-    post '/epp/command/info', { frame: authentication_enabled_epp_request_xml },
-         'HTTP_COOKIE' => "session=#{session.session_id}"
+    post '/epp/command/info', params: { frame: authentication_enabled_epp_request_xml },
+         headers: { 'HTTP_COOKIE' => "session=#{session.session_id}" }
+
     session.reload
 
     assert_epp_response :completed_successfully

--- a/test/tasks/epp/clear_expired_sessions_test.rb
+++ b/test/tasks/epp/clear_expired_sessions_test.rb
@@ -1,11 +1,19 @@
 require 'test_helper'
 
 class EppClearExpiredSessionsTaskTest < ActiveSupport::TestCase
+  setup do
+    @original_session_timeout = EppSession.timeout
+  end
+
+  teardown do
+    EppSession.timeout = @original_session_timeout
+  end
+
   def test_clears_expired_epp_sessions
-    idle_timeout = 0.second
-    EppSession.idle_timeout = idle_timeout
+    timeout = 0.second
+    EppSession.timeout = timeout
     session = epp_sessions(:api_bestnames)
-    session.update!(updated_at: Time.zone.now - idle_timeout - 1.second)
+    session.update!(updated_at: Time.zone.now - timeout - 1.second)
 
     run_task
 

--- a/test/tasks/epp/clear_expired_sessions_test.rb
+++ b/test/tasks/epp/clear_expired_sessions_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class EppClearExpiredSessionsTaskTest < ActiveSupport::TestCase
+  def test_clears_expired_epp_sessions
+    idle_timeout = 0.second
+    EppSession.idle_timeout = idle_timeout
+    session = epp_sessions(:api_bestnames)
+    session.update!(updated_at: Time.zone.now - idle_timeout - 1.second)
+
+    run_task
+
+    assert_nil EppSession.find_by(session_id: session.session_id)
+  end
+
+  private
+
+  def run_task
+    Rake::Task['epp:clear_expired_sessions'].execute
+  end
+end

--- a/test/tasks/epp/clear_expired_sessions_test.rb
+++ b/test/tasks/epp/clear_expired_sessions_test.rb
@@ -10,14 +10,15 @@ class EppClearExpiredSessionsTaskTest < ActiveSupport::TestCase
   end
 
   def test_clears_expired_epp_sessions
-    timeout = 0.second
-    EppSession.timeout = timeout
+    timeout = EppSession.timeout
     session = epp_sessions(:api_bestnames)
+    next_session = epp_sessions(:api_goodnames)
     session.update!(updated_at: Time.zone.now - timeout - 1.second)
 
     run_task
 
     assert_nil EppSession.find_by(session_id: session.session_id)
+    assert EppSession.find_by(session_id: next_session.session_id)
   end
 
   private


### PR DESCRIPTION
@ratM1n @teadur 
- There is a new rake task `epp:clear_expired_sessions`. It should be scheduled to run periodically, depending on how often we want to purge expired sessions. Needed to be run manually on deploy, or otherwise nobody will be able to login.
- New setting https://github.com/internetee/registry/pull/1331/files#diff-fc5026eef1f4752ef71315b36727e708R161

Fixes #711