### PR TITLE
Remove unused EPP routes

### DIFF
--- a/app/controllers/epp/errors_controller.rb
+++ b/app/controllers/epp/errors_controller.rb
@@ -6,10 +6,5 @@ module Epp
       epp_errors << { code: params[:code], msg: params[:msg] }
       render_epp_response '/epp/error'
     end
-
-    def not_found
-      epp_errors << { code: 2400, msg: t(:could_not_determine_object_type_check_xml_format_and_namespaces) }
-      render_epp_response '/epp/error'
-    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -365,7 +365,6 @@ en:
   request_method: 'Request method'
   response_code: 'Response code'
   request_params: 'Request params'
-  could_not_determine_object_type_check_xml_format_and_namespaces: 'Could not determine object type. Check XML format and namespaces.'
   unknown_expiry_relative_pattern: 'Expiry relative must be compatible to ISO 8601'
   unknown_expiry_absolute_pattern: 'Expiry absolute must be compatible to ISO 8601'
   mutally_exclusive_params: 'Mutually exclusive parameters: %{params}'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,17 +3,13 @@ require_dependency 'epp_constraint'
 Rails.application.routes.draw do
   namespace(:epp, defaults: { format: :xml }) do
     match 'session/:action', controller: 'sessions', via: :all, constraints: EppConstraint.new(:session)
-    match 'session/pki/:action', controller: 'sessions', via: :all, constraints: EppConstraint.new(:session)
 
     post 'command/:action', controller: 'domains', constraints: EppConstraint.new(:domain)
     post 'command/:action', controller: 'contacts', constraints: EppConstraint.new(:contact)
     post 'command/poll',     to: 'polls#poll', constraints: EppConstraint.new(:poll)
     post 'command/keyrelay', to: 'keyrelays#keyrelay', constraints: EppConstraint.new(:keyrelay)
 
-    post 'command/:command', to: 'errors#not_found', constraints: EppConstraint.new(:not_found) # fallback route
-
     get 'error/:command', to: 'errors#error'
-    match "*command", to: 'errors#error', via: [:post, :get, :patch, :put, :delete]
   end
 
   mount Repp::API => '/'

--- a/doc/controllers_complete.svg
+++ b/doc/controllers_complete.svg
@@ -123,7 +123,6 @@
 <text text-anchor="middle" x="808" y="-13.8" font-family="Times,serif" font-size="14.00">Epp::ErrorsController</text>
 <polyline fill="none" stroke="black" points="740.5,-6 875.5,-6 "/>
 <text text-anchor="start" x="748.5" y="9.2" font-family="Times,serif" font-size="14.00">error</text>
-<text text-anchor="start" x="748.5" y="24.2" font-family="Times,serif" font-size="14.00">not_found</text>
 <polyline fill="none" stroke="black" points="740.5,32 875.5,32 "/>
 <polyline fill="none" stroke="black" points="740.5,56 875.5,56 "/>
 <text text-anchor="start" x="748.5" y="71.2" font-family="Times,serif" font-size="14.00">_layout</text>

--- a/lib/epp_constraint.rb
+++ b/lib/epp_constraint.rb
@@ -15,7 +15,7 @@ class EppConstraint
     request.params[:nokogiri_frame] ||= Nokogiri::XML(request.params[:raw_frame] || request.params[:frame])
     request.params[:parsed_frame]   ||= request.params[:nokogiri_frame].dup.remove_namespaces!
 
-    unless [:keyrelay, :poll, :session, :not_found].include?(@type)
+    unless [:keyrelay, :poll, :session].include?(@type)
       element = "//#{@type}:#{request.params[:action]}"
       return false if request.params[:nokogiri_frame].xpath("#{element}", OBJECT_TYPES[@type]).none?
     end

--- a/test/integration/epp/base_test.rb
+++ b/test/integration/epp/base_test.rb
@@ -13,16 +13,9 @@ class EppBaseTest < EppTestCase
            constraints: EppConstraint.new(:poll)
     end
 
-    any_valid_epp_request_xml = <<-XML
-      <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-      <epp xmlns="https://epp.tld.ee/schema/epp-ee-1.0.xsd">
-        <hello/>
-      </epp>
-    XML
-
     begin
       assert_difference 'ApiLog::EppLog.count' do
-        post '/epp/command/internal_error', { frame: any_valid_epp_request_xml },
+        post '/epp/command/internal_error', { frame: valid_request_xml },
              'HTTP_COOKIE' => 'session=api_bestnames'
       end
       assert_epp_response :command_failed
@@ -33,14 +26,13 @@ class EppBaseTest < EppTestCase
     end
   end
 
-  def test_invalid_request
+  def test_validates_request_xml
     invalid_xml = <<-XML
       <?xml version="1.0" encoding="UTF-8" standalone="no"?>
       <epp xmlns="https://epp.tld.ee/schema/epp-ee-1.0.xsd">
       </epp>
     XML
-    post '/epp/command/internal_error', { frame: invalid_xml },
-         'HTTP_COOKIE' => 'session=api_bestnames'
+    post valid_command_path, { frame: invalid_xml }, 'HTTP_COOKIE' => 'session=api_bestnames'
 
     assert_epp_response :syntax_error
   end
@@ -86,5 +78,20 @@ class EppBaseTest < EppTestCase
          'HTTP_COOKIE' => "session=#{session.session_id}"
 
     assert_epp_response :authorization_error
+  end
+
+  private
+
+  def valid_command_path
+    epp_command_poll_path
+  end
+
+  def valid_request_xml
+    <<-XML
+      <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+      <epp xmlns="https://epp.tld.ee/schema/epp-ee-1.0.xsd">
+        <hello/>
+      </epp>
+    XML
   end
 end


### PR DESCRIPTION
Removes routes that are not supported by EPP proxy.

https://github.com/internetee/epp_proxy#translation-of-epp-calls