### PR TITLE
Fix mailer preview

### DIFF
--- a/test/mailers/previews/contact_mailer_preview.rb
+++ b/test/mailers/previews/contact_mailer_preview.rb
@@ -6,7 +6,8 @@ class ContactMailerPreview < ActionMailer::Preview
                              EXISTS(SELECT 1 FROM domain_contacts WHERE domain_contacts.contact_id =
                              contacts.id)')
 
-    contact = contact.where.not(email: nil, country_code: nil, code: nil).first
+    contact = contact.where.not(email: nil, country_code: nil, ident_country_code: nil, code: nil)
+              .take
 
     ContactMailer.email_changed(contact: contact, old_email: 'old@inbox.test')
   end

--- a/test/mailers/previews/registrant_change_mailer_preview.rb
+++ b/test/mailers/previews/registrant_change_mailer_preview.rb
@@ -1,7 +1,11 @@
 class RegistrantChangeMailerPreview < ActionMailer::Preview
   def initialize
-    @domain = Domain.first
-    @new_registrant = Registrant.where.not(email: nil, country_code: nil).first
+    @domain = Domain.joins(:registrant).where.not({ contacts: { email: nil,
+                                                                country_code: nil,
+                                                                ident_country_code: nil } }).take
+    @new_registrant = Registrant.where.not(email: nil,
+                                           country_code: nil,
+                                           ident_country_code: nil).take
     super
   end
 
@@ -21,7 +25,7 @@ class RegistrantChangeMailerPreview < ActionMailer::Preview
 
   def accepted
     RegistrantChangeMailer.accepted(domain: @domain,
-                                    old_registrant: @domain.registrar)
+                                    old_registrant: @domain.registrant)
   end
 
   def rejected


### PR DESCRIPTION
Fixes 
- `/rails/mailers/registrant_change_mailer/accepted` 
- `/rails/mailers/contact_mailer/email_changed` 

mailer preview on staging.

Please verify it, since my database differs from staging.

Does not affect production code.