### PR TITLE
Remove `money` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,6 @@ gem 'grape'
 # registry specfic
 gem 'isikukood' # for EE-id validation
 gem 'simpleidn', '0.0.7' # For punycode
-gem 'money-rails'
 gem 'data_migrate'
 gem 'whenever', '0.9.4', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,15 +228,6 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.12.2)
-    monetize (1.9.0)
-      money (~> 6.12)
-    money (6.12.0)
-      i18n (>= 0.6.4, < 1.1)
-    money-rails (1.12.0)
-      activesupport (>= 3.0)
-      monetize (~> 1.9.0)
-      money (~> 6.12.0)
-      railties (>= 3.0)
     multi_json (1.13.1)
     mustermann (1.0.3)
     mustermann-grape (1.0.0)
@@ -452,7 +443,6 @@ DEPENDENCIES
   kaminari (= 0.16.3)
   lhv!
   mina (= 0.3.1)
-  money-rails
   nokogiri
   paper_trail (~> 4.0)
   pdfkit

--- a/app/controllers/epp/domains_controller.rb
+++ b/app/controllers/epp/domains_controller.rb
@@ -80,7 +80,7 @@ module Epp
 
         if @domain.save # TODO: Maybe use validate: false here because we have already validated the domain?
           current_user.registrar.debit!({
-                                          sum: @domain_pricelist.price.amount,
+                                          sum: @domain_pricelist.price,
                                           description: "#{I18n.t('create')} #{@domain.name}",
                                           activity_type: AccountActivity::CREATE,
                                           price: @domain_pricelist
@@ -162,7 +162,7 @@ module Epp
             end
 
             current_user.registrar.debit!({
-                                            sum: @domain_pricelist.price.amount,
+                                            sum: @domain_pricelist.price,
                                             description: "#{I18n.t('renew')} #{@domain.name}",
                                             activity_type: AccountActivity::RENEW,
                                             price: @domain_pricelist
@@ -321,7 +321,7 @@ module Epp
     def balance_ok?(operation, period = nil, unit = nil)
       @domain_pricelist = @domain.pricelist(operation, period.try(:to_i), unit)
       if @domain_pricelist.try(:price) # checking if price list is not found
-        if current_user.registrar.balance < @domain_pricelist.price.amount
+        if current_user.registrar.balance < @domain_pricelist.price
           epp_errors << {
             code: '2104',
             msg: I18n.t('billing_failure_credit_balance_low')

--- a/app/models/billing/price.rb
+++ b/app/models/billing/price.rb
@@ -5,13 +5,13 @@ module Billing
     belongs_to :zone, class_name: 'DNS::Zone', required: true
     has_many :account_activities
 
-    validates :price, :valid_from, :operation_category, :duration, presence: true
+    validates :valid_from, :operation_category, :duration, presence: true
+    validates :price, presence: true, numericality: { greater_than_or_equal_to: 0 }
     validates :operation_category, inclusion: { in: Proc.new { |price| price.class.operation_categories } }
     validates :duration, inclusion: { in: Proc.new { |price| price.class.durations } }
 
     alias_attribute :effect_time, :valid_from
     alias_attribute :expire_time, :valid_to
-    monetize :price_cents, allow_nil: true, numericality: { greater_than_or_equal_to: 0 }
     after_initialize :init_values
 
     def self.operation_categories

--- a/app/models/directo.rb
+++ b/app/models/directo.rb
@@ -97,7 +97,7 @@ class Directo < ActiveRecord::Base
                 "ProductID" => DOMAIN_TO_PRODUCT[price.zone_name],
                 "Unit" => "tk",
                 "ProductName" => ".#{price.zone_name} registreerimine: #{price.duration.to_i} aasta#{price.duration.to_i > 1 ? 't' : ''}",
-                "UnitPriceWoVAT" => price.price.amount / price.duration.to_i
+                "UnitPriceWoVAT" => price.price / price.duration.to_i
             }
             hash["StartDate"] = (activity.created_at + (year-1).year).end_of_month.strftime(date_format) if year > 1
             hash["EndDate"] = (activity.created_at + (year-1).year + 1).end_of_month.strftime(date_format) if year > 1
@@ -120,7 +120,7 @@ class Directo < ActiveRecord::Base
                 "ProductID" => DOMAIN_TO_PRODUCT[price.zone_name],
                 "Unit" => "tk",
                 "ProductName" => ".#{price.zone_name} registreerimine: #{price.duration.to_i} kuud",
-                "UnitPriceWoVAT" => price.price.amount,
+                "UnitPriceWoVAT" => price.price,
             }
 
             if items.has_key?(hash)

--- a/app/views/admin/billing/prices/_form.html.erb
+++ b/app/views/admin/billing/prices/_form.html.erb
@@ -31,7 +31,7 @@
         <div class="col-sm-3">
             <div class="input-group">
                 <%= f.money_field :price, class: 'form-control', required: true %>
-                <div class="input-group-addon"><%= Money::default_currency.symbol %></div>
+                <div class="input-group-addon">€</div>
             </div>
         </div>
     </div>

--- a/app/views/admin/billing/prices/edit.html.erb
+++ b/app/views/admin/billing/prices/edit.html.erb
@@ -21,7 +21,7 @@
     <div class="alert alert-info">
         <% active_price = ::Billing::Price.price_for(@price.zone, @price.operation_category, @price.duration) %>
         <% if active_price %>
-            <%= t('active_price_for_this_operation_is', price: "#{active_price.price.amount.to_s} EUR") %>
+            <%= t('active_price_for_this_operation_is', price: "#{active_price.price} EUR") %>
         <% else %>
             <%= t('active_price_missing_for_this_operation') %>
         <% end %>

--- a/app/views/registrar/settings/balance_auto_reload/form/types/_threshold.erb
+++ b/app/views/registrar/settings/balance_auto_reload/form/types/_threshold.erb
@@ -10,7 +10,7 @@
         <div class="col-md-2">
             <div class="input-group">
                 <%= f.money_field :amount, required: true, autofocus: true, class: 'form-control' %>
-                <div class="input-group-addon"><%= Money::default_currency.symbol %></div>
+                <div class="input-group-addon">€</div>
             </div>
         </div>
 
@@ -25,7 +25,7 @@
         <div class="col-md-2">
             <div class="input-group">
                 <%= f.money_field :threshold, required: true, class: 'form-control' %>
-                <div class="input-group-addon"><%= Money::default_currency.symbol %></div>
+                <div class="input-group-addon">€</div>
             </div>
         </div>
     </div>

--- a/config/initializers/money.rb
+++ b/config/initializers/money.rb
@@ -1,4 +1,0 @@
-MoneyRails.configure do |config|
-  # Wrapper for Money#default_currency with additional functionality
-  config.default_currency = :eur
-end

--- a/db/migrate/20191015144353_change_prices_price_to_numeric.rb
+++ b/db/migrate/20191015144353_change_prices_price_to_numeric.rb
@@ -1,0 +1,6 @@
+class ChangePricesPriceToNumeric < ActiveRecord::Migration
+  def change
+    change_column :prices, :price_cents, 'numeric(10,2) USING price_cents / 100'
+    rename_column :prices, :price_cents, :price
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1950,7 +1950,7 @@ ALTER SEQUENCE public.notifications_id_seq OWNED BY public.notifications.id;
 
 CREATE TABLE public.prices (
     id integer NOT NULL,
-    price_cents integer NOT NULL,
+    price numeric(10,2) NOT NULL,
     valid_from timestamp without time zone,
     valid_to timestamp without time zone,
     creator_str character varying,
@@ -4877,4 +4877,6 @@ INSERT INTO schema_migrations (version) VALUES ('20191005162437');
 INSERT INTO schema_migrations (version) VALUES ('20191007123000');
 
 INSERT INTO schema_migrations (version) VALUES ('20191008024334');
+
+INSERT INTO schema_migrations (version) VALUES ('20191015144353');
 

--- a/test/fixtures/billing/prices.yml
+++ b/test/fixtures/billing/prices.yml
@@ -1,6 +1,6 @@
 create_one_month:
   duration: 3 mons
-  price_cents: 100
+  price: 1
   operation_category: create
   valid_from: 2010-07-05
   valid_to: 2010-07-05
@@ -8,7 +8,7 @@ create_one_month:
 
 renew_one_month:
   duration: 1 mons
-  price_cents: 100
+  price: 1
   operation_category: renew
   valid_from: 2010-07-05
   valid_to: 2010-07-05
@@ -16,14 +16,14 @@ renew_one_month:
 
 create_one_year:
   duration: 1 year
-  price_cents: 1000
+  price: 10
   operation_category: create
   valid_from: 2010-07-05
   zone: one
 
 renew_one_year:
   duration: 1 year
-  price_cents: 1000
+  price: 10
   operation_category: renew
   valid_from: 2010-07-05
   valid_to: 2010-07-05

--- a/test/learning/money_test.rb
+++ b/test/learning/money_test.rb
@@ -1,8 +1,0 @@
-require 'test_helper'
-
-class MoneyLearningTest < ActiveSupport::TestCase
-  def test_default_currency_is_euro
-    money = Money.from_amount(1)
-    assert_equal Money::Currency.new(:eur), money.currency
-  end
-end

--- a/test/models/billing/price_test.rb
+++ b/test/models/billing/price_test.rb
@@ -24,7 +24,7 @@ class Billing::PriceTest < ActiveSupport::TestCase
     price.price = 0
     assert price.valid?, proc { price.errors.full_messages }
 
-    price.price = "1#{I18n.t('number.currency.format.separator')}1"
+    price.price = 1.1
     assert price.valid?
 
     price.price = 1


### PR DESCRIPTION
Triggered by https://github.com/internetee/registry/issues/377, but I thought it would anyway be a good idea to get rid of additional dependency (which we don't actually use to the full extent) with quite little effort.

Affects billing and Directo integration.

Converts column type https://github.com/internetee/registry/pull/1365/files#diff-6979bcc7d7cf39dc881a09e613b83c9fR3.

Removes deprecation message on Rails 5:

> You are using the default localization behaviour that will change in the next major release. Find out more - https://github.com/RubyMoney/money#deprecation