### PR TITLE
Do not handle EPP contact:renew

### DIFF
--- a/app/controllers/epp/contacts_controller.rb
+++ b/app/controllers/epp/contacts_controller.rb
@@ -70,12 +70,6 @@ module Epp
       end
     end
 
-    def renew
-      authorize! :renew, Epp::Contact
-      epp_errors << { code: '2101', msg: t(:'errors.messages.unimplemented_command') }
-      handle_errors
-    end
-
     def transfer
       authorize! :transfer, Epp::Contact
       epp_errors << { code: '2101', msg: t(:'errors.messages.unimplemented_command') }

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -63,7 +63,6 @@ class Ability
     can(:create, Epp::Contact)
     can(:update, Epp::Contact) { |c, pw| c.registrar_id == @user.registrar_id || c.auth_info == pw }
     can(:delete, Epp::Contact) { |c, pw| c.registrar_id == @user.registrar_id || c.auth_info == pw }
-    can(:renew,  Epp::Contact)
     can(:transfer,  Epp::Contact)
     can(:view_password, Epp::Contact) { |c, pw| c.registrar_id == @user.registrar_id || c.auth_info == pw }
   end


### PR DESCRIPTION
I think it makes no sense (or rather impossible) to handle such command on registry app level, since there is just no such command/request defined (it's not even listed in [EPP XML schema](https://github.com/internetee/registry/blob/7c1e030f453a0bf2092bb066b5173b917fd4493e/lib/schemas/contact-ee-1.1.xsd#L27) which we validate against, so it will fail anyway). So I just removed the code that handled it altogether. App should just fail and return internal error back to EPP proxy. I am not sure we need to handle this on proxy level either, since it is not expected that someone will try to send such request.

Related to #1362