### PR TITLE
Fix typo

### DIFF
--- a/app/models/epp/domain.rb
+++ b/app/models/epp/domain.rb
@@ -480,7 +480,7 @@ class Epp::Domain < Domain
     same_registrant_as_current = (registrant.code == frame.css('registrant').text)
 
     if !same_registrant_as_current && errors.empty? && verify &&
-       Setting.request_confrimation_on_registrant_change_enabled &&
+       Setting.verify_registrant_change &&
        frame.css('registrant').present? &&
        frame.css('registrant').attr('verified').to_s.downcase != 'yes'
       registrant_verification_asked!(frame.to_s, current_user.id)

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -63,7 +63,7 @@ class Setting < RailsSettings::Base
       client_side_status_editing_enabled
       registrar_ip_whitelist_enabled
       api_ip_whitelist_enabled
-      request_confrimation_on_registrant_change_enabled
+      verify_registrant_change
       request_confirmation_on_domain_deletion_enabled
       nameserver_required
       address_processing

--- a/app/views/admin/settings/index.haml
+++ b/app/views/admin/settings/index.haml
@@ -45,7 +45,7 @@
           = render 'setting_row', var: :client_side_status_editing_enabled
           = render 'setting_row', var: :api_ip_whitelist_enabled
           = render 'setting_row', var: :registrar_ip_whitelist_enabled
-          = render 'setting_row', var: :request_confrimation_on_registrant_change_enabled
+          = render 'setting_row', var: :verify_registrant_change
           = render 'setting_row', var: :request_confirmation_on_domain_deletion_enabled
           = render 'setting_row', var: :address_processing
 

--- a/config/app.yml
+++ b/config/app.yml
@@ -17,7 +17,7 @@ defaults: &defaults
   ns_max_count: 11
 
   transfer_wait_time: 0
-  request_confrimation_on_registrant_change_enabled: true
+  verify_registrant_change: true
   request_confirmation_on_domain_deletion_enabled: true
   address_processing: true
   default_language: en

--- a/lib/tasks/data_migrations/rename_setting.rake
+++ b/lib/tasks/data_migrations/rename_setting.rake
@@ -1,0 +1,8 @@
+namespace :data_migrations do
+  task rename_setting: :environment do
+    Setting.transaction do
+      Setting.destroy(:request_confrimation_on_registrant_change_enabled)
+      Setting.verify_registrant_change = true
+    end
+  end
+end

--- a/test/integration/epp/domain/update/base_test.rb
+++ b/test/integration/epp/domain/update/base_test.rb
@@ -5,14 +5,12 @@ class EppDomainUpdateBaseTest < EppTestCase
 
   setup do
     @domain = domains(:shop)
-    @original_registrant_change_verification =
-      Setting.request_confrimation_on_registrant_change_enabled
+    @original_verify_registrant_change = Setting.verify_registrant_change
     ActionMailer::Base.deliveries.clear
   end
 
   teardown do
-    Setting.request_confrimation_on_registrant_change_enabled =
-      @original_registrant_change_verification
+    Setting.verify_registrant_change = @original_verify_registrant_change
   end
 
   def test_update_domain
@@ -84,7 +82,7 @@ class EppDomainUpdateBaseTest < EppTestCase
   end
 
   def test_requires_verification_from_current_registrant_when_provided_registrant_is_a_new_one
-    Setting.request_confrimation_on_registrant_change_enabled = true
+    Setting.verify_registrant_change = true
     new_registrant = contacts(:william).becomes(Registrant)
     assert_not_equal new_registrant, @domain.registrant
 
@@ -120,7 +118,7 @@ class EppDomainUpdateBaseTest < EppTestCase
   end
 
   def test_requires_verification_from_current_registrant_when_not_yet_verified_by_registrar
-    Setting.request_confrimation_on_registrant_change_enabled = true
+    Setting.verify_registrant_change = true
     new_registrant = contacts(:william)
     assert_not_equal new_registrant, @domain.registrant
 
@@ -156,7 +154,7 @@ class EppDomainUpdateBaseTest < EppTestCase
   end
 
   def test_skips_verification_when_provided_registrant_is_the_same_as_current_one
-    Setting.request_confrimation_on_registrant_change_enabled = true
+    Setting.verify_registrant_change = true
 
     request_xml = <<-XML
       <?xml version="1.0" encoding="UTF-8" standalone="no"?>
@@ -189,7 +187,7 @@ class EppDomainUpdateBaseTest < EppTestCase
   end
 
   def test_skips_verification_when_disabled
-    Setting.request_confrimation_on_registrant_change_enabled = false
+    Setting.verify_registrant_change = false
     new_registrant = contacts(:william).becomes(Registrant)
     assert_not_equal new_registrant, @domain.registrant
 
@@ -225,7 +223,7 @@ class EppDomainUpdateBaseTest < EppTestCase
   end
 
   def test_skips_verification_from_current_registrant_when_already_verified_by_registrar
-    Setting.request_confrimation_on_registrant_change_enabled = true
+    Setting.verify_registrant_change = true
     new_registrant = contacts(:william).becomes(Registrant)
     assert_not_equal new_registrant, @domain.registrant
 


### PR DESCRIPTION
Rename `request_confrimation_on_registrant_change_enabled` setting to
`verify_registrant_change`.

@internetee/sysadmins `data_migrations:rename_setting` rake task must be run manually in order to remove old setting and create a new one (it will work anyway since the default value of a new one is the same we use, but it's better to persist the changes, and this is what this task does).

Fixes #371