### PR TITLE
Update `haml` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,7 @@ gem 'company_register', github: 'internetee/company_register', branch: :master
 gem 'e_invoice', github: 'internetee/e_invoice', branch: :master
 gem 'lhv', github: 'internetee/lhv', tag: 'v0.1.0'
 gem 'domain_name'
-gem 'haml'
+gem 'haml', '~> 5.0'
 gem 'wkhtmltopdf-binary'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,7 +187,8 @@ GEM
       virtus (>= 1.0.0)
     gyoku (1.3.1)
       builder (>= 2.1.2)
-    haml (4.0.7)
+    haml (5.1.2)
+      temple (>= 0.8.0)
       tilt
     hashdiff (1.0.0)
     hpricot (0.8.6)
@@ -382,9 +383,10 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    temple (0.8.2)
     thor (0.20.3)
     thread_safe (0.3.6)
-    tilt (1.4.1)
+    tilt (2.0.10)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.1.11)
@@ -447,7 +449,7 @@ DEPENDENCIES
   epp-xml (= 1.1.0)!
   figaro (= 1.1.1)
   grape
-  haml
+  haml (~> 5.0)
   isikukood
   iso8601 (= 0.8.6)
   jquery-rails


### PR DESCRIPTION
Addresses https://nvd.nist.gov/vuln/detail/CVE-2017-1002201.

I couldn't find any incompatibilities in [changelog](https://github.com/haml/haml/blob/master/CHANGELOG.md).