### PR TITLE
Downgrade `minitest` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,4 +100,5 @@ group :test do
   gem 'simplecov', require: false
   gem 'webdrivers'
   gem 'webmock'
+  gem 'minitest', '~> 5.10.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,7 +227,7 @@ GEM
       rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.12.2)
+    minitest (5.10.3)
     monetize (1.9.0)
       money (~> 6.12)
     money (6.12.0)
@@ -452,6 +452,7 @@ DEPENDENCIES
   kaminari (= 0.16.3)
   lhv!
   mina (= 0.3.1)
+  minitest (~> 5.10.0)
   money-rails
   nokogiri
   paper_trail (~> 4.0)


### PR DESCRIPTION
Minitest > 5.10 is not compatible with Rails 5.0.x (#377)

https://github.com/seattlerb/minitest/issues/730