### PR TITLE
Do not show `dnskey` and `nameserver` errors in UI

### DIFF
--- a/app/views/admin/domains/partials/_dnskeys.haml
+++ b/app/views/admin/domains/partials/_dnskeys.haml
@@ -1,5 +1,5 @@
 - panel_class = @domain.errors.messages[:dnskeys] ? 'panel-danger' : 'panel-default'
-#dnskeys.panel{class: panel_class}
+.panel{class: panel_class}
   .panel-heading.clearfix
     = t(:dnskeys)
   .table-responsive

--- a/app/views/admin/domains/partials/_dnskeys.haml
+++ b/app/views/admin/domains/partials/_dnskeys.haml
@@ -1,5 +1,4 @@
-- panel_class = @domain.errors.messages[:dnskeys] ? 'panel-danger' : 'panel-default'
-.panel{class: panel_class}
+.panel.panel-default
   .panel-heading.clearfix
     = t(:dnskeys)
   .table-responsive
@@ -17,9 +16,3 @@
             %td= x.protocol
             %td= x.alg
             %td= x.public_key
-      - if @domain.errors.messages[:dnskeys]
-        %tfoot
-          - @domain.errors.messages[:dnskeys].each do |x|
-            %tr
-              %td{colspan: 4}= x
-

--- a/app/views/admin/domains/partials/_nameservers.haml
+++ b/app/views/admin/domains/partials/_nameservers.haml
@@ -1,5 +1,4 @@
-- panel_class = @domain.errors.messages[:nameservers] ? 'panel-danger' : 'panel-default'
-.panel{class: panel_class}
+.panel.panel-default
   .panel-heading.clearfix
     = t(:nameservers)
   .table-responsive
@@ -15,9 +14,3 @@
             %td= x
             %td= x.ipv4
             %td= x.ipv6
-      - if @domain.errors.messages[:nameservers]
-        %tfoot
-          - @domain.errors.messages[:nameservers].each do |x|
-            %tr
-              %td{colspan: 3}= x
-

--- a/app/views/admin/domains/partials/_nameservers.haml
+++ b/app/views/admin/domains/partials/_nameservers.haml
@@ -1,5 +1,5 @@
 - panel_class = @domain.errors.messages[:nameservers] ? 'panel-danger' : 'panel-default'
-#nameservers.panel{class: panel_class}
+.panel{class: panel_class}
   .panel-heading.clearfix
     = t(:nameservers)
   .table-responsive

--- a/app/views/admin/domains/partials/_tech_contacts.haml
+++ b/app/views/admin/domains/partials/_tech_contacts.haml
@@ -1,6 +1,6 @@
 - tech_contacts_invalid = @domain.errors.include?(:tech_contacts)
 - panel_class = tech_contacts_invalid ? 'panel-danger' : 'panel-default'
-#tech_contacts.panel{class: panel_class}
+.panel{class: panel_class}
   .panel-heading.clearfix
     = t('.title')
   .table-responsive

--- a/app/views/registrant/domains/partials/_dnskeys.haml
+++ b/app/views/registrant/domains/partials/_dnskeys.haml
@@ -1,5 +1,5 @@
 - panel_class = @domain.errors.messages[:dnskeys] ? 'panel-danger' : 'panel-default'
-#dnskeys.panel{class: panel_class}
+.panel{class: panel_class}
   .panel-heading.clearfix
     = t(:dnskeys)
   .table-responsive

--- a/app/views/registrant/domains/partials/_dnskeys.haml
+++ b/app/views/registrant/domains/partials/_dnskeys.haml
@@ -1,5 +1,4 @@
-- panel_class = @domain.errors.messages[:dnskeys] ? 'panel-danger' : 'panel-default'
-.panel{class: panel_class}
+.panel.panel-default
   .panel-heading.clearfix
     = t(:dnskeys)
   .table-responsive
@@ -17,9 +16,3 @@
             %td= x.protocol
             %td= x.alg
             %td= x.public_key
-      - if @domain.errors.messages[:dnskeys]
-        %tfoot
-          - @domain.errors.messages[:dnskeys].each do |x|
-            %tr
-              %td{colspan: 4}= x
-

--- a/app/views/registrant/domains/partials/_nameservers.haml
+++ b/app/views/registrant/domains/partials/_nameservers.haml
@@ -1,5 +1,4 @@
-- panel_class = @domain.errors.messages[:nameservers] ? 'panel-danger' : 'panel-default'
-.panel{class: panel_class}
+.panel.panel-default
   .panel-heading.clearfix
     = t(:nameservers)
   .table-responsive
@@ -15,9 +14,3 @@
             %td= x
             %td= x.ipv4
             %td= x.ipv6
-      - if @domain.errors.messages[:nameservers]
-        %tfoot
-          - @domain.errors.messages[:nameservers].each do |x|
-            %tr
-              %td{colspan: 3}= x
-

--- a/app/views/registrant/domains/partials/_nameservers.haml
+++ b/app/views/registrant/domains/partials/_nameservers.haml
@@ -1,5 +1,5 @@
 - panel_class = @domain.errors.messages[:nameservers] ? 'panel-danger' : 'panel-default'
-#nameservers.panel{class: panel_class}
+.panel{class: panel_class}
   .panel-heading.clearfix
     = t(:nameservers)
   .table-responsive

--- a/app/views/registrar/domains/partials/_contacts.haml
+++ b/app/views/registrar/domains/partials/_contacts.haml
@@ -1,4 +1,4 @@
-#tech_contacts.panel.panel-default
+.panel.panel-default
   .panel-heading.clearfix
     %h3.panel-title= t(:contacts)
   .table-responsive

--- a/app/views/registrar/domains/partials/_nameservers.haml
+++ b/app/views/registrar/domains/partials/_nameservers.haml
@@ -1,4 +1,4 @@
-#nameservers.panel.panel-default
+.panel.panel-default
   .panel-heading.clearfix
     %h3.panel-title= t(:nameservers)
   .table-responsive


### PR DESCRIPTION
Fixes issues listed under "Registrant" section in https://github.com/internetee/registry/issues/377#issuecomment-548913083.

https://prnt.sc/pt7n70 UI is quite poor, but it was so before. Will be addressed in a separate PR later.