### PR TITLE
Regenerate `whois` database schema

### DIFF
--- a/db/whois_schema.rb
+++ b/db/whois_schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,41 +10,33 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181102124618) do
+ActiveRecord::Schema.define(version: 2018_11_02_124618) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "ar_internal_metadata", primary_key: "key", force: :cascade do |t|
-    t.string   "value"
+  create_table "contact_requests", force: :cascade do |t|
+    t.integer "whois_record_id", null: false
+    t.string "secret", null: false
+    t.string "email", null: false
+    t.string "name", null: false
+    t.datetime "valid_to", null: false
+    t.string "status", default: "new", null: false
+    t.inet "ip_address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_contact_requests_on_email"
+    t.index ["ip_address"], name: "index_contact_requests_on_ip_address"
+    t.index ["secret"], name: "index_contact_requests_on_secret", unique: true
+    t.index ["whois_record_id"], name: "index_contact_requests_on_whois_record_id"
   end
-
-  create_table "contact_requests", id: :bigserial, force: :cascade do |t|
-    t.integer  "whois_record_id",                 null: false
-    t.string   "secret",                          null: false
-    t.string   "email",                           null: false
-    t.string   "name",                            null: false
-    t.datetime "valid_to",                        null: false
-    t.string   "status",          default: "new", null: false
-    t.inet     "ip_address"
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
-  end
-
-  add_index "contact_requests", ["email"], name: "index_contact_requests_on_email", using: :btree
-  add_index "contact_requests", ["ip_address"], name: "index_contact_requests_on_ip_address", using: :btree
-  add_index "contact_requests", ["secret"], name: "index_contact_requests_on_secret", unique: true, using: :btree
-  add_index "contact_requests", ["whois_record_id"], name: "index_contact_requests_on_whois_record_id", using: :btree
 
   create_table "whois_records", force: :cascade do |t|
-    t.string   "name"
-    t.json     "json"
+    t.string "name"
+    t.json "json"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_domains_on_name"
   end
-
-  add_index "whois_records", ["name"], name: "index_domains_on_name", using: :btree
 
 end


### PR DESCRIPTION
Remove outdated structure of `ar_internal_metadata` table and let
Rails create it by itself.

Otherwise `bin/rails db:setup:all` fails with:

> PG::InvalidTextRepresentation: ERROR:  invalid input syntax for
> integer: "environment": SELECT  "ar_internal_metadata".* FROM
> "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1 LIMIT $2