### PR TITLE
Remove Ruby version from Travis config and let it use .ruby-version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: ruby
-rvm:
-  - 2.4
-  - 2.5
 cache: bundler
 env:
   - DB=postgresql


### PR DESCRIPTION
Does not affect production code.