### PR TITLE
Fix epp domains controller to apply add or rem changes to status

### DIFF
--- a/app/controllers/epp/domains_controller.rb
+++ b/app/controllers/epp/domains_controller.rb
@@ -311,11 +311,17 @@ module Epp
 
     def status_editing_disabled
       return true if Setting.client_status_editing_enabled
+      return true if check_client_hold
       return true if params[:parsed_frame].css('status').empty?
       epp_errors << {
         code: '2306',
         msg: "#{I18n.t(:client_side_status_editing_error)}: status [status]"
       }
+    end
+
+    def check_client_hold
+      statuses = params[:parsed_frame].css('status').map { |element| element['s'] }
+      statuses == [::DomainStatus::CLIENT_HOLD]
     end
 
     def balance_ok?(operation, period = nil, unit = nil)


### PR DESCRIPTION
From this patch epp domains controller will allow to update
domain statuses only if there is only one status - clientHold.
This was made to allow usage of new ForceDelete procedures.

See #762, #1428