### PR TITLE
Add :show action to admin api_user routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -271,7 +271,7 @@ Rails.application.routes.draw do
 
     resources :admin_users
     # /admin/api_users is mainly for manual testing
-    resources :api_users, only: :index do
+    resources :api_users, only: [:index, :show] do
       resources :certificates do
         member do
           post 'sign'


### PR DESCRIPTION
In application_helper.rb we are generating link to  creator/updater, but if contact creator is API user, there is an error as we are trying to create link_to(api_user) without having a :show route. This commit fixes this.

Closes #1458