### PR TITLE
Fix ignored attributes on history models

### DIFF
--- a/app/models/concerns/versions.rb
+++ b/app/models/concerns/versions.rb
@@ -61,7 +61,8 @@ module Versions
           preceding(time + 1, true).
           select("distinct on (item_id) #{ver_klass.table_name}.*").
           map do |ver|
-            o = new(ver.object)
+            ignored_columns = ver.item_type.constantize&.ignored_columns
+            o = new(ver.object&.except!(*ignored_columns))
             o.version_loader = ver
             ver.object_changes.to_h.each { |k, v| o.public_send("#{k}=", v[-1]) }
             o

--- a/app/models/concerns/versions.rb
+++ b/app/models/concerns/versions.rb
@@ -61,8 +61,8 @@ module Versions
           preceding(time + 1, true).
           select("distinct on (item_id) #{ver_klass.table_name}.*").
           map do |ver|
-            ignored_columns = ver.item_type.constantize&.ignored_columns
-            o = new(ver.object&.except!(*ignored_columns))
+            valid_columns = ver.item_type.constantize&.column_names
+            o = new(ver.object&.slice(*valid_columns))
             o.version_loader = ver
             ver.object_changes.to_h.each { |k, v| o.public_send("#{k}=", v[-1]) }
             o

--- a/test/models/concerns/versions_test.rb
+++ b/test/models/concerns/versions_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class VersionsTest < ActiveSupport::TestCase
+
+  def test_if_gets_all_versions_without_error_if_ignored_column_present
+    @nameserver = nameservers(:shop_ns1)
+    @nameserver.update(hostname: 'ns99.bestnames.test')
+    @ignored_column_title = Nameserver.ignored_columns.first
+
+    version = NameserverVersion.last
+    hash = version.object
+    hash[@ignored_column_title] = 123456
+    version.update(object: hash)
+
+    assert_nothing_raised do
+      Nameserver.all_versions_for([@nameserver.id], Time.zone.now)
+    end
+  end
+
+  def test_if_gets_all_versions_without_error_if_no_ignored_column
+    @account = accounts(:cash)
+    @account.update(currency: 'USD')
+
+    assert_nothing_raised do
+      Account.all_versions_for([@account.id], Time.zone.now)
+    end
+  end
+end


### PR DESCRIPTION
Concern method #all_versions_for(ids, time) tries to create model instance from
history and raises an exception if there are some columns in history object 
which are ignored in model at the moment.

This patch removes ignored columns from data used to create a new instance.

See #1489. Additional info https://github.com/internetee/registry/issues/1489#issuecomment-578131793