### PR TITLE
Registrar/Domains: Allow :s as search parameter

### DIFF
--- a/app/controllers/registrar/domains_controller.rb
+++ b/app/controllers/registrar/domains_controller.rb
@@ -184,7 +184,8 @@ class Registrar
                                   :contacts_ident_eq,
                                   :nameservers_hostname_eq,
                                   :valid_to_gteq,
-                                  :valid_to_lteq)
+                                  :valid_to_lteq,
+                                  :s)
     end
   end
 end


### PR DESCRIPTION
Closes #1461 