### PR TITLE
Bind specific invoice when paid via Banklink / EveryPay

### DIFF
--- a/app/controllers/registrar/payments_controller.rb
+++ b/app/controllers/registrar/payments_controller.rb
@@ -27,6 +27,8 @@ class Registrar
       opts = { response: params }
       @payment = ::PaymentOrders.create_with_type(params[:bank], invoice, opts)
       if @payment.valid_response_from_intermediary? && @payment.settled_payment?
+        Rails.logger.info("User paid invoice ##{invoice.number} successfully")
+
         @payment.complete_transaction
 
         if invoice.paid?

--- a/app/models/bank_transaction.rb
+++ b/app/models/bank_transaction.rb
@@ -48,6 +48,7 @@ class BankTransaction < ApplicationRecord
     end
 
     invoice = Invoice.find_by(number: invoice_no)
+    @registrar = invoice.buyer
 
     unless invoice
       errors.add(:base, I18n.t('invoice_was_not_found'))

--- a/app/models/payment_orders/base.rb
+++ b/app/models/payment_orders/base.rb
@@ -26,6 +26,32 @@ module PaymentOrders
       transaction.save!
     end
 
+    def compose_or_find_transaction
+      transaction = BankTransaction.find_by(base_transaction_params)
+
+      # Transaction already autobinded (possibly) invalid invoice
+      if transaction.binded?
+        Rails.logger.info("Transaction #{transaction.id} is already binded")
+        Rails.logger.info('Creating new BankTransaction record.')
+
+        transaction = new_base_transaction
+      end
+
+      transaction
+    end
+
+    def new_base_transaction
+      BankTransaction.new(base_transaction_params)
+    end
+
+    def base_transaction_params
+      {
+        description: invoice.order,
+        currency: invoice.currency,
+        iban: invoice.seller_iban,
+      }
+    end
+
     def form_url
       ENV["payments_#{type}_url"]
     end

--- a/test/models/payment_orders/bank_link_test.rb
+++ b/test/models/payment_orders/bank_link_test.rb
@@ -114,7 +114,9 @@ class BankLinkTest < ActiveSupport::TestCase
     mock_transaction.expect(:paid_at= , Date.parse('2018-04-01 00:30:00 +0300'), [Time.parse('2018-04-01T00:30:00+0300')])
     mock_transaction.expect(:buyer_name=, 'John Doe', ['John Doe'])
     mock_transaction.expect(:save!, true)
-    mock_transaction.expect(:autobind_invoice, AccountActivity.new)
+    mock_transaction.expect(:binded?, false)
+    mock_transaction.expect(:bind_invoice, AccountActivity.new, [1])
+    mock_transaction.expect(:errors, [])
 
     BankTransaction.stub(:find_by, mock_transaction) do
       @completed_bank_link.complete_transaction

--- a/test/models/payment_orders/every_pay_test.rb
+++ b/test/models/payment_orders/every_pay_test.rb
@@ -72,7 +72,9 @@ class EveryPayTest < ActiveSupport::TestCase
     mock_transaction.expect(:paid_at= , Date.strptime('1524136727', '%s'), [Date.strptime('1524136727', '%s')])
     mock_transaction.expect(:buyer_name=, 'John Doe', ['John Doe'])
     mock_transaction.expect(:save!, true)
-    mock_transaction.expect(:autobind_invoice, AccountActivity.new)
+    mock_transaction.expect(:binded?, false)
+    mock_transaction.expect(:bind_invoice, AccountActivity.new, [1])
+    mock_transaction.expect(:errors, [])
 
     BankTransaction.stub(:find_by, mock_transaction) do
       @every_pay.complete_transaction


### PR DESCRIPTION
Closes #1500 

Creates new BankTransaction in case previous one is already binded with account activity. When attempting to complete transaction, it attempts to bind specific invoice directly (bind_invoice) instead of autobinding (autobind_invoices).