### PR TITLE
disable airbrake performance monitoring

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -3,6 +3,9 @@ Airbrake.configure do |config|
   config.project_id = ENV['airbrake_project_id']
   config.project_key = ENV['airbrake_project_key']
   config.root_directory = Rails.root
+  config.job_stats = false
+  config.query_stats = false
+  config.performance_stats = false
   config.logger =
     if ENV['RAILS_LOG_TO_STDOUT'].present?
       Logger.new(STDOUT, level: Rails.logger.level)


### PR DESCRIPTION
Currently airbrake is sending performance monitoring to our errbit, but errbit does not implement said performance metrics and we are just spamming our errbit/airbrake logs with errors.

Henche i'm disabling performance monitoring sending via airbrake according to: https://github.com/errbit/errbit/issues/1450#issuecomment-585847987