### PR TITLE
Fix redirect back

### DIFF
--- a/app/controllers/admin/zonefiles_controller.rb
+++ b/app/controllers/admin/zonefiles_controller.rb
@@ -13,7 +13,7 @@ module Admin
         send_data @zonefile, filename: "#{params[:origin]}.txt"
       else
         flash[:alert] = 'Origin not supported'
-        redirect_to :back
+        redirect_back(fallback_location: root_path)
       end
     end
   end

--- a/app/controllers/registrar/current_user_controller.rb
+++ b/app/controllers/registrar/current_user_controller.rb
@@ -6,7 +6,7 @@ class Registrar
       raise 'Cannot switch to unlinked user' unless current_registrar_user.linked_with?(new_user)
 
       sign_in(:registrar_user, new_user)
-      redirect_to :back, notice: t('.switched', new_user: new_user)
+      redirect_back(fallback_location: root_path, notice: t('.switched', new_user: new_user))
     end
 
     private


### PR DESCRIPTION
Note that `redirect_to :back` was deprecated in Rails 5.0 ([deprecation PR](https://github.com/rails/rails/pull/22506)) and then removed in Rails 5.1 .

Closes #1535