### PR TITLE
Rollback SimpleCov to 0.17.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,7 @@ group :test do
   gem 'capybara'
   gem 'database_cleaner'
   gem 'minitest', '~> 5.14'
-  gem 'simplecov', require: false
+  gem 'simplecov', '0.17.1', require: false # CC last supported v0.17
   gem 'webdrivers'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -413,10 +413,11 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    simplecov (0.18.1)
+    simplecov (0.17.1)
       docile (~> 1.1)
-      simplecov-html (~> 0.11.0)
-    simplecov-html (0.11.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     simpleidn (0.0.9)
     sinatra (2.0.8.1)
       mustermann (~> 1.0)
@@ -521,7 +522,7 @@ DEPENDENCIES
   sdoc (= 0.4.1)
   select2-rails (= 3.5.9.3)
   selectize-rails (= 0.12.1)
-  simplecov
+  simplecov (= 0.17.1)
   simpleidn (= 0.0.9)
   uglifier
   validates_email_format_of (= 1.6.3)


### PR DESCRIPTION
..as CodeClimate hasn't provided support for SimpleCov 0.18 yet. Results in no test coverage data on PRs nor master branch.

https://docs.codeclimate.com/docs/configuring-test-coverage