### PR TITLE
Add auctions endpoint to REPP

### DIFF
--- a/app/controllers/repp/v1/auctions_controller.rb
+++ b/app/controllers/repp/v1/auctions_controller.rb
@@ -1,0 +1,23 @@
+module Repp
+  module V1
+    class AuctionsController < ActionController::API
+      def index
+        auctions = Auction.started
+
+        render json: { count: auctions.count,
+                       auctions: auctions_to_json(auctions) }
+      end
+
+      private
+
+      def auctions_to_json(auctions)
+        auctions.map do |e|
+          {
+            domain_name: e.domain,
+            punycode_domain_name: SimpleIDN.to_ascii(e.domain),
+          }
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,11 +41,12 @@ Rails.application.routes.draw do
 
   namespace :repp do
     namespace :v1 do
+      resources :auctions, only: %i[index]
       resources :retained_domains, only: %i[index]
     end
   end
 
-  match 'repp/v1/retained_domains',
+  match 'repp/v1/*all',
         controller: 'api/cors',
         action: 'cors_preflight_check',
         via: [:options],

--- a/doc/repp/v1/auctions.md
+++ b/doc/repp/v1/auctions.md
@@ -1,0 +1,39 @@
+## GET /repp/v1/auctions
+
+Return a list of auctions currently in progress. The list of domains changes
+every day.
+
+In contrast with other endpoints in REPP, this one is publicly available for
+anyone without authentication.
+
+#### Request
+
+```
+GET /repp/v1/auctions HTTP/1.1
+Host: registry.test
+User-Agent: curl/7.64.1
+Accept: */*
+```
+
+#### Response
+
+```
+HTTP/1.1 200 OK
+Date: Thu, 21 May 2020 10:39:45 GMT
+Content-Type: application/json; charset=utf-8
+ETag: W/"217bd9ee4dfbb332172a1baf80ee0ba9"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: a26b6801-bf3f-4922-b0db-3b081bacb130
+X-Runtime: 1.481174
+Transfer-Encoding: chunked
+
+{
+  "count":1,
+  "auctions": [
+    {
+      "domain_name": "auctionäöüõ.test",
+      "punycode_domain_name": "xn--auction-cxa7mj0e.test"
+    }
+  ]
+}
+```

--- a/doc/repp_doc.md
+++ b/doc/repp_doc.md
@@ -21,3 +21,4 @@ Main communication specification through Restful EPP (REPP):
 [Account related functions](repp/v1/account.md)
 [Nameservers](repp/v1/nameservers.md)
 [Retained domains](repp/v1/retained_domains.md)
+[Auctions](repp/v1/auctions.md)

--- a/test/integration/repp/auctions_test.rb
+++ b/test/integration/repp/auctions_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class ReppV1AuctionsTest < ActionDispatch::IntegrationTest
+  setup do
+    @auction = auctions(:one)
+
+    @auction.update!(uuid: '1b3ee442-e8fe-4922-9492-8fcb9dccc69c',
+                     domain: 'auction.test',
+                     status: Auction.statuses[:started])
+  end
+
+  def test_get_index
+    get repp_v1_auctions_path
+    response_json = JSON.parse(response.body, symbolize_names: true)
+
+    assert response_json[:count] == 1
+
+    expected_response = [{ domain_name: @auction.domain,
+                           punycode_domain_name: @auction.domain }]
+
+    assert_equal expected_response, response_json[:auctions]
+  end
+end


### PR DESCRIPTION
Includes name in both formats, if something else needs to be added to this endpoint for registars' benefit, it can be developed.