### PR TITLE
Add disputed domains to retained API

### DIFF
--- a/app/models/retained_domains.rb
+++ b/app/models/retained_domains.rb
@@ -3,6 +3,7 @@
 class RetainedDomains
   RESERVED = 'reserved'.freeze
   BLOCKED = 'blocked'.freeze
+  DISPUTED = 'disputed'.freeze
 
   attr_reader :domains,
               :type
@@ -26,14 +27,15 @@ class RetainedDomains
     case type
     when RESERVED then :reserved
     when BLOCKED then :blocked
+    when DISPUTED then :disputed
     else :all
     end
   end
 
   def gather_domains
-    domains = blocked_domains.to_a.union(reserved_domains.to_a)
-
-    domains.sort_by(&:name)
+    blocked_domains.to_a
+                   .union(reserved_domains.to_a)
+                   .union(disputed_domains.to_a)
   end
 
   def blocked_domains
@@ -52,16 +54,30 @@ class RetainedDomains
     end
   end
 
+  def disputed_domains
+    if %i[all disputed].include?(type)
+      Dispute.order(domain_name: :desc).active
+    else
+      []
+    end
+  end
+
   def domain_to_jsonable(domain)
     status = case domain
              when ReservedDomain then RESERVED
              when BlockedDomain then BLOCKED
+             when Dispute then DISPUTED
              end
 
-    punycode = SimpleIDN.to_ascii(domain.name)
+    domain_name = case domain
+                  when Dispute then domain.domain_name
+                  else domain.name
+                  end
+
+    punycode = SimpleIDN.to_ascii(domain_name)
 
     {
-      name: domain.name,
+      name: domain_name,
       status: status,
       punycode_name: punycode,
     }

--- a/app/models/retained_domains.rb
+++ b/app/models/retained_domains.rb
@@ -63,17 +63,8 @@ class RetainedDomains
   end
 
   def domain_to_jsonable(domain)
-    status = case domain
-             when ReservedDomain then RESERVED
-             when BlockedDomain then BLOCKED
-             when Dispute then DISPUTED
-             end
-
-    domain_name = case domain
-                  when Dispute then domain.domain_name
-                  else domain.name
-                  end
-
+    status = get_status(domain)
+    domain_name = get_domain_name(domain)
     punycode = SimpleIDN.to_ascii(domain_name)
 
     {
@@ -81,5 +72,20 @@ class RetainedDomains
       status: status,
       punycode_name: punycode,
     }
+  end
+
+  def get_status(domain)
+    case domain
+    when ReservedDomain then RESERVED
+    when BlockedDomain then BLOCKED
+    when Dispute then DISPUTED
+    end
+  end
+
+  def get_domain_name(domain)
+    case domain
+    when Dispute then domain.domain_name
+    else domain.name
+    end
   end
 end

--- a/doc/repp/v1/retained_domains.md
+++ b/doc/repp/v1/retained_domains.md
@@ -1,16 +1,20 @@
 ## GET /repp/v1/retained_domains
 
-Return a list of reserved and blocked domains, along with total count. You can
-filter them by type of the domain, which can be either reserved or blocked.
+Return a list of disputed, reserved and blocked domains, along with total count.
+You can filter them by type of the domain, which can be: `reserved`, `blocked`
+or `disputed`.
+
+NB! A domain name can be both `disputed` and `reserved` at the same time, and it
+will appear on the list as two separate objects.
 
 In contrast with other endpoints in REPP, this one is publicly available for
 anyone without authentication.
 
 #### Parameters
 
-| Field name | Required |  Type   |     Allowed values      |        Description         |
-| ---------- | -------- |  ----   |  --------------         |        -----------         |
-|   type     |  false   | string  | ["reserved", "blocked"] | Type of domains to show    |
+| Field name | Required |  Type   |     Allowed values                  |        Description         |
+| ---------- | -------- |  ----   |  --------------                     |        -----------         |
+|   type     |  false   | string  | ["reserved", "blocked", "disputed"] | Type of domains to show    |
 
 
 #### Request


### PR DESCRIPTION
Fixes #1588. Testing via curl:

```bash
$ curl -v -X GET "https://registry.test/repp/v1/retained_domains?type=disputed"
```