### PR TITLE
Fix registration deadline format for whois/restwhois

### DIFF
--- a/app/models/auction.rb
+++ b/app/models/auction.rb
@@ -24,7 +24,7 @@ class Auction < ApplicationRecord
   end
 
   def whois_deadline
-    registration_deadline.to_s
+    registration_deadline.try(:to_s, :iso8601)
   end
 
   def mark_as_no_bids

--- a/test/models/whois/record_test.rb
+++ b/test/models/whois/record_test.rb
@@ -50,7 +50,8 @@ class Whois::RecordTest < ActiveSupport::TestCase
     assert_equal ({ 'name' => 'domain.test',
                     'status' => ['PendingRegistration'],
                     'disclaimer' => 'disclaimer',
-                    'registration_deadline' => registration_deadline.to_s }), @whois_record.json
+                    'registration_deadline' => registration_deadline.try(:to_s, :iso8601) }),
+                 @whois_record.json
   end
 
   def test_updates_whois_record_from_auction_when_payment_received
@@ -64,7 +65,8 @@ class Whois::RecordTest < ActiveSupport::TestCase
     assert_equal ({ 'name' => 'domain.test',
                     'status' => ['PendingRegistration'],
                     'disclaimer' => 'disclaimer',
-                    'registration_deadline' => registration_deadline.to_s }), @whois_record.json
+                    'registration_deadline' => registration_deadline.try(:to_s, :iso8601) }),
+                 @whois_record.json
   end
 
   def registration_deadline


### PR DESCRIPTION
sviiter added the registration deadline to internet.ee as well, but said that restwhois returns registration deadline in different format than other dates

"registration_deadline": "2020-06-02 23:59:59 +0300"

while others are:

"changed": "2018-04-10T11:11:15+03:00",
"nameservers_changed": "2017-10-01T23:42:13+03:00",
"registrar_changed": "2020-05-22T13:52:16+03:00",

For this reason Firefox returns invalid date (Chrome parses the date correctly).