### PR TITLE
Pump coffee-rails from 4.2 to 5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'nokogiri'
 
 # style
 gem 'bootstrap-sass', '~> 3.4'
-gem 'coffee-rails', '~> 4.2'
+gem 'coffee-rails', '>= 5.0'
 gem 'jquery-rails'
 gem 'selectize-rails', '0.12.1' # include selectize.js for select
 gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,9 +157,9 @@ GEM
     childprocess (3.0.0)
     chronic (0.10.2)
     coderay (1.1.0)
-    coffee-rails (4.2.2)
+    coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
-      railties (>= 4.0.0)
+      railties (>= 5.2.0)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -498,7 +498,7 @@ DEPENDENCIES
   cancancan
   capybara
   coderay (= 1.1.0)
-  coffee-rails (~> 4.2)
+  coffee-rails (>= 5.0)
   company_register!
   countries
   daemons-rails (= 1.2.1)


### PR DESCRIPTION
Resolves deprecation issues with single arity template handlers