### PR TITLE
Extract Xml deserializing from EPP Contact and Domain classes

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,3 +1,5 @@
+require 'deserializers/xml/legal_document'
+
 class Contact < ApplicationRecord
   include Versions # version/contact_version.rb
   include EppErrors
@@ -351,7 +353,7 @@ class Contact < ApplicationRecord
       return false
     end
 
-    legal_document_data = Epp::Domain.parse_legal_document_from_frame(frame)
+    legal_document_data = ::Deserializers::Xml::LegalDocument.new(frame).call
 
     if legal_document_data
 

--- a/app/models/epp/contact.rb
+++ b/app/models/epp/contact.rb
@@ -1,4 +1,5 @@
 require 'deserializers/xml/legal_document'
+require 'deserializers/xml/ident'
 
 class Epp::Contact < Contact
   include EppErrors
@@ -40,8 +41,8 @@ class Epp::Contact < Contact
 
       at[:auth_info]    = f.css('authInfo pw').text            if f.css('authInfo pw').present?
 
-
-      at.merge!(ident_attrs(f.css('ident').first)) if new_record
+      ident_attrs = ::Deserializers::Xml::Ident.new(f).call
+      at.merge!(ident_attrs) if new_record
       at
     end
 
@@ -54,25 +55,6 @@ class Epp::Contact < Contact
           registrar: registrar
         )
       )
-    end
-
-    def ident_attrs(ident_frame)
-      return {} unless ident_attr_valid?(ident_frame)
-
-      {
-        ident: ident_frame.text,
-        ident_type: ident_frame.attr('type'),
-        ident_country_code: ident_frame.attr('cc')
-      }
-    end
-
-    def ident_attr_valid?(ident_frame)
-      return false if ident_frame.blank?
-      return false if ident_frame.try('text').blank?
-      return false if ident_frame.attr('type').blank?
-      return false if ident_frame.attr('cc').blank?
-
-      true
     end
 
     def legal_document_attrs(legal_frame)

--- a/app/models/epp/contact.rb
+++ b/app/models/epp/contact.rb
@@ -1,3 +1,5 @@
+require 'deserializers/xml/legal_document'
+
 class Epp::Contact < Contact
   include EppErrors
 
@@ -140,7 +142,7 @@ class Epp::Contact < Contact
       at[:statuses] = statuses - statuses_attrs(frame.css('rem'), 'rem') + statuses_attrs(frame.css('add'), 'add')
     end
 
-    if doc = attach_legal_document(Epp::Domain.parse_legal_document_from_frame(frame))
+    if doc = attach_legal_document(::Deserializers::Xml::LegalDocument.new(frame).call)
       frame.css("legalDocument").first.content = doc.path if doc&.persisted?
       self.legal_document_id = doc.id
     end
@@ -237,7 +239,7 @@ class Epp::Contact < Contact
   end
 
   def add_legal_file_to_new frame
-    legal_document_data = Epp::Domain.parse_legal_document_from_frame(frame)
+    legal_document_data = ::Deserializers::Xml::LegalDocument.new(frame).call
     return unless legal_document_data
 
     doc = LegalDocument.create(

--- a/app/models/epp/contact.rb
+++ b/app/models/epp/contact.rb
@@ -57,17 +57,6 @@ class Epp::Contact < Contact
       )
     end
 
-    def legal_document_attrs(legal_frame)
-      return [] if legal_frame.blank?
-      return [] if legal_frame.try('text').blank?
-      return [] if legal_frame.attr('type').blank?
-
-      [{
-        body: legal_frame.text,
-        document_type: legal_frame.attr('type')
-      }]
-    end
-
     def check_availability(codes)
       codes = [codes] if codes.is_a?(String)
 

--- a/lib/deserializers/xml/ident.rb
+++ b/lib/deserializers/xml/ident.rb
@@ -1,0 +1,34 @@
+module Deserializers
+  module Xml
+    class Ident
+      attr_reader :frame
+
+      def initialize(frame)
+        @frame = frame.css('ident').first
+      end
+
+      def call
+        if valid?
+          {
+            ident: frame.text,
+            ident_type: frame.attr('type'),
+            ident_country_code: frame.attr('cc')
+          }
+        else
+          {}
+        end
+      end
+
+      private
+
+      def valid?
+        return false if frame.blank?
+        return false if frame.try('text').blank?
+        return false if frame.attr('type').blank?
+        return false if frame.attr('cc').blank?
+
+        true
+      end
+    end
+  end
+end

--- a/lib/deserializers/xml/ident.rb
+++ b/lib/deserializers/xml/ident.rb
@@ -12,7 +12,7 @@ module Deserializers
           {
             ident: frame.text,
             ident_type: frame.attr('type'),
-            ident_country_code: frame.attr('cc')
+            ident_country_code: frame.attr('cc'),
           }
         else
           {}

--- a/lib/deserializers/xml/legal_document.rb
+++ b/lib/deserializers/xml/legal_document.rb
@@ -1,0 +1,22 @@
+module Deserializers
+  module Xml
+    # Given a nokogiri frame, extract information about legal document from it.
+    class LegalDocument
+      attr_reader :frame
+
+      def initialize(frame)
+        @frame = frame
+      end
+
+      def call
+        ld = frame.css('legalDocument').first
+        return unless ld
+
+        {
+          body: ld.text,
+          type: ld['type']
+        }
+      end
+    end
+  end
+end

--- a/lib/deserializers/xml/legal_document.rb
+++ b/lib/deserializers/xml/legal_document.rb
@@ -14,7 +14,7 @@ module Deserializers
 
         {
           body: ld.text,
-          type: ld['type']
+          type: ld['type'],
         }
       end
     end

--- a/test/lib/deserializers/xml/ident_test.rb
+++ b/test/lib/deserializers/xml/ident_test.rb
@@ -1,0 +1,95 @@
+require 'test_helper'
+require 'deserializers/xml/ident'
+
+class DeserializersXmlIdentTest < ActiveSupport::TestCase
+  def test_returns_empty_hash_when_not_present
+    xml_string = <<-XML
+      <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+      <epp xmlns="https://epp.tld.ee/schema/epp-ee-1.0.xsd">
+        <command>
+          <update>
+            <contact:update xmlns:contact="https://epp.tld.ee/schema/contact-ee-1.1.xsd">
+              <contact:id>john-001</contact:id>
+              <contact:chg>
+                <contact:postalInfo>
+                  <contact:name>new name</contact:name>
+                </contact:postalInfo>
+                <contact:voice>+123.4</contact:voice>
+                <contact:email>new-email@inbox.test</contact:email>
+              </contact:chg>
+            </contact:update>
+          </update>
+        </command>
+      </epp>
+    XML
+
+    nokogiri_frame = Nokogiri::XML(xml_string).remove_namespaces!
+    instance = ::Deserializers::Xml::Ident.new(nokogiri_frame)
+    assert_equal instance.call, {}
+  end
+
+  def test_returns_empty_hash_when_not_valid
+    xml_string = <<-XML
+      <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+      <epp xmlns="https://epp.tld.ee/schema/epp-ee-1.0.xsd">
+        <command>
+          <delete>
+            <contact:delete xmlns:contact="https://epp.tld.ee/schema/contact-ee-1.1.xsd">
+              <contact:id>FIRST0:SH2027223711</contact:id>
+              <contact:authInfo>
+                <contact:pw>wrong password</contact:pw>
+              </contact:authInfo>
+            </contact:delete>
+          </delete>
+          <extension>
+            <eis:extdata xmlns:eis="https://epp.tld.ee/schema/eis-1.0.xsd">
+              <eis:ident cc="EE">37605030299</eis:ident>
+              <eis:legalDocument type="pdf">dGVzdCBmYWlsCg==</eis:legalDocument>
+            </eis:extdata>
+          </extension>
+          <clTRID>ABC-12345</clTRID>
+        </command>
+      </epp>
+    XML
+
+    nokogiri_frame = Nokogiri::XML(xml_string).remove_namespaces!
+    instance = ::Deserializers::Xml::Ident.new(nokogiri_frame)
+    assert_equal instance.call, {}
+  end
+
+  def test_returns_complete_hash_when_valid
+    xml_string = <<-XML
+      <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+      <epp xmlns="https://epp.tld.ee/schema/epp-ee-1.0.xsd">
+        <command>
+          <delete>
+            <contact:delete xmlns:contact="https://epp.tld.ee/schema/contact-ee-1.1.xsd">
+              <contact:id>FIRST0:SH2027223711</contact:id>
+              <contact:authInfo>
+                <contact:pw>wrong password</contact:pw>
+              </contact:authInfo>
+            </contact:delete>
+          </delete>
+          <extension>
+            <eis:extdata xmlns:eis="https://epp.tld.ee/schema/eis-1.0.xsd">
+              <eis:ident type="priv" cc="EE">37605030299</eis:ident>
+              <eis:legalDocument type="pdf">dGVzdCBmYWlsCg==</eis:legalDocument>
+            </eis:extdata>
+          </extension>
+          <clTRID>ABC-12345</clTRID>
+        </command>
+      </epp>
+    XML
+
+    nokogiri_frame = Nokogiri::XML(xml_string).remove_namespaces!
+    instance = ::Deserializers::Xml::Ident.new(nokogiri_frame)
+
+    expected_result = {
+      ident: '37605030299',
+      ident_type: 'priv',
+      ident_country_code: 'EE'
+    }
+
+    assert_equal instance.call, expected_result
+  end
+end

--- a/test/lib/deserializers/xml/legal_document_test.rb
+++ b/test/lib/deserializers/xml/legal_document_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+require 'deserializers/xml/legal_document'
+
+class DeserializersXmlLegalDocumentTest < ActiveSupport::TestCase
+  def test_returns_nil_when_required_fields_not_present
+    xml_string = <<-XML
+      <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+      <epp xmlns="https://epp.tld.ee/schema/epp-ee-1.0.xsd">
+        <command>
+          <update>
+            <contact:update xmlns:contact="https://epp.tld.ee/schema/contact-ee-1.1.xsd">
+              <contact:id>john-001</contact:id>
+              <contact:chg>
+                <contact:postalInfo>
+                  <contact:name>new name</contact:name>
+                </contact:postalInfo>
+                <contact:voice>+123.4</contact:voice>
+                <contact:email>new-email@inbox.test</contact:email>
+              </contact:chg>
+            </contact:update>
+          </update>
+        </command>
+      </epp>
+    XML
+
+    nokogiri_frame = Nokogiri::XML(xml_string).remove_namespaces!
+    instance = ::Deserializers::Xml::LegalDocument.new(nokogiri_frame)
+
+    assert_nil instance.call
+  end
+
+  def test_returns_hash_when_document_exists
+    xml_string = <<-XML
+      <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+      <epp xmlns="https://epp.tld.ee/schema/epp-ee-1.0.xsd">
+        <command>
+          <delete>
+            <contact:delete xmlns:contact="https://epp.tld.ee/schema/contact-ee-1.1.xsd">
+              <contact:id>FIRST0:SH2027223711</contact:id>
+              <contact:authInfo>
+                <contact:pw>wrong password</contact:pw>
+              </contact:authInfo>
+            </contact:delete>
+          </delete>
+          <extension>
+            <eis:extdata xmlns:eis="https://epp.tld.ee/schema/eis-1.0.xsd">
+              <eis:ident type="priv" cc="EE">37605030299</eis:ident>
+              <eis:legalDocument type="pdf">dGVzdCBmYWlsCg==</eis:legalDocument>
+            </eis:extdata>
+          </extension>
+          <clTRID>ABC-12345</clTRID>
+        </command>
+      </epp>
+    XML
+
+    nokogiri_frame = Nokogiri::XML(xml_string).remove_namespaces!
+    instance = ::Deserializers::Xml::LegalDocument.new(nokogiri_frame)
+    expected_result = { body: "dGVzdCBmYWlsCg==", type: "pdf" }
+
+    assert_equal expected_result, instance.call
+  end
+end


### PR DESCRIPTION
This is first of many steps in untangling Contact/Update from EPP and converting it to a more sequential processing.

Please check that you can still attach documents and set idents via EPP, it should work as previously, since the functionality is quite well tested so I'm confident it is fine :)