### PR TITLE
Fix not running whois update after contact update

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -502,7 +502,8 @@ class Contact < ApplicationRecord
 
   def update_related_whois_records
     # not doing anything if no real changes
-    return if changes.slice(*(self.class.column_names - ["updated_at", "created_at", "statuses", "status_notes"])).empty?
+    ignored_columns = %w[updated_at created_at statuses status_notes]
+    return if saved_changes.slice(*(self.class.column_names - ignored_columns)).empty?
 
     names = related_domain_descriptions.keys
     UpdateWhoisRecordJob.enqueue(names, 'domain') if names.present?

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,6 +1,6 @@
 
 Rails.application.configure do
-  $VERBOSE = nil
+  # $VERBOSE = nil
   # Settings specified here will take precedence over those in config/application.rb.
 
   # The test environment is used exclusively to run your application's

--- a/test/models/contact_test.rb
+++ b/test/models/contact_test.rb
@@ -248,6 +248,15 @@ class ContactTest < ActiveSupport::TestCase
     assert_equal %w[ok], contact.statuses
   end
 
+  def test_whois_gets_updated_after_contact_save
+    @contact.name = 'SomeReallyWeirdRandomTestName'
+    domain = @contact.registrant_domains.first
+
+    @contact.save!
+
+    assert_equal domain.whois_record.try(:json).try(:[], 'registrant'), @contact.name
+  end
+
   private
 
   def make_contact_free_of_domains_where_it_acts_as_a_registrant(contact)


### PR DESCRIPTION
Closes #1604

```DEPRECATION WARNING: The behavior of changed? inside of after callbacks will be changing in the next version of Rails. The new return value will reflect the behavior of calling the method after save returned (e.g. the opposite of what it returns now). To maintain the current behavior, use saved_changes? instead.

DEPRECATION WARNING: The behavior of changed_attributes inside of after callbacks will be changing in the next version of Rails. The new return value will reflect the behavior of calling the method after save returned (e.g. the opposite of what it returns now). To maintain the current behavior, use saved_changes.transform_values(&:first) instead.

DEPRECATION WARNING: The behavior of attribute_changed? inside of after callbacks will be changing in the next version of Rails. The new return value will reflect the behavior of calling the method after save returned (e.g. the opposite of what it returns now). To maintain the current behavior, use saved_change_to_attribute? instead.

DEPRECATION WARNING: The behavior of attribute_was inside of after callbacks will be changing in the next version of Rails. The new return value will reflect the behavior of calling the method after save returned (e.g. the opposite of what it returns now). To maintain the current behavior, use attribute_before_last_save instead.
```


So we need to check all the using of dirty model changes checks in all the app. Also removed silencer from test config.