### PR TITLE
add email field to contact serializer

### DIFF
--- a/lib/serializers/registrant_api/domain.rb
+++ b/lib/serializers/registrant_api/domain.rb
@@ -58,7 +58,7 @@ module Serializers
 
         array_of_contacts = []
         contact_pool.map do |contact|
-          array_of_contacts.push(name: contact.name, id: contact.uuid)
+          array_of_contacts.push(name: contact.name, id: contact.uuid, email: contact.email)
         end
 
         array_of_contacts

--- a/test/integration/api/registrant/registrant_api_domains_test.rb
+++ b/test/integration/api/registrant/registrant_api_domains_test.rb
@@ -20,9 +20,13 @@ class RegistrantApiDomainsTest < ApplicationIntegrationTest
     assert_equal('hospital.test', domain[:name])
     assert_equal('5edda1a5-3548-41ee-8b65-6d60daf85a37', domain[:id])
     assert_equal({name: 'John', id: 'eb2f2766-b44c-4e14-9f16-32ab1a7cb957'}, domain[:registrant])
-    assert_equal([{name: 'John', id: 'eb2f2766-b44c-4e14-9f16-32ab1a7cb957'}],
+    assert_equal([{name: 'John',
+                   id: 'eb2f2766-b44c-4e14-9f16-32ab1a7cb957',
+                   email: 'john@inbox.test'}],
                  domain[:admin_contacts])
-    assert_equal([{name: 'John', id: 'eb2f2766-b44c-4e14-9f16-32ab1a7cb957'}],
+    assert_equal([{name: 'John',
+                   id: 'eb2f2766-b44c-4e14-9f16-32ab1a7cb957',
+                   email: 'john@inbox.test'}],
                  domain[:tech_contacts])
     assert_equal({ name: 'Good Names', website: nil }, domain[:registrar])
     assert_equal([], domain[:nameservers])

--- a/test/integration/api/registrant/registrant_api_registry_locks_test.rb
+++ b/test/integration/api/registrant/registrant_api_registry_locks_test.rb
@@ -131,9 +131,18 @@ class RegistrantApiRegistryLocksTest < ApplicationIntegrationTest
 
     assert_equal({ name: 'Best Names', website: 'https://bestnames.test' }, response_json[:registrar])
     assert_equal({name: 'John', id: 'eb2f2766-b44c-4e14-9f16-32ab1a7cb957'}, response_json[:registrant])
-    assert_equal([{name: 'Jane', id: '9db3de62-2414-4487-bee2-d5c155567768'}], response_json[:admin_contacts])
-    assert_equal([{name: 'William', id: '0aa54704-d6f7-4ca9-b8ca-2827d9a4e4eb'},
-                  {name: 'Acme Ltd', id: 'f1dd365c-5be9-4b3d-a44e-3fa002465e4d'}].to_set,
+    assert_equal([{name: 'Jane',
+                   id: '9db3de62-2414-4487-bee2-d5c155567768',
+                   email: 'jane@mail.test'
+                  }],
+                 response_json[:admin_contacts])
+    assert_equal([{name: 'William',
+                   id: '0aa54704-d6f7-4ca9-b8ca-2827d9a4e4eb',
+                   email: 'william@inbox.test'},
+                  {name: 'Acme Ltd',
+                   id: 'f1dd365c-5be9-4b3d-a44e-3fa002465e4d',
+                   email: 'acme@outlook.test'
+                  }].to_set,
                  response_json[:tech_contacts].to_set)
     assert_equal(
       [{hostname: 'ns1.bestnames.test', ipv4: ['192.0.2.1'], ipv6: ['2001:db8::1']},

--- a/test/lib/serializers/registrant_api/domain_test.rb
+++ b/test/lib/serializers/registrant_api/domain_test.rb
@@ -36,11 +36,17 @@ class SerializersRegistrantApiDomainTest < ActiveSupport::TestCase
   end
 
   def test_returns_contacts_name_and_uuid
-    assert_equal([{name: 'John', id: 'eb2f2766-b44c-4e14-9f16-32ab1a7cb957'},
-                  {name: 'William', id: '0aa54704-d6f7-4ca9-b8ca-2827d9a4e4eb'}].to_set,
+    assert_equal([{name: 'John',
+                   id: 'eb2f2766-b44c-4e14-9f16-32ab1a7cb957',
+                   email: 'john@inbox.test'},
+                  {name: 'William',
+                   id: '0aa54704-d6f7-4ca9-b8ca-2827d9a4e4eb',
+                   email: 'william@inbox.test'}].to_set,
                  @json[:admin_contacts].to_set)
 
-    assert_equal([{name: 'William', id: '0aa54704-d6f7-4ca9-b8ca-2827d9a4e4eb'}].to_set,
+    assert_equal([{name: 'William',
+                   id: '0aa54704-d6f7-4ca9-b8ca-2827d9a4e4eb',
+                   email: 'william@inbox.test'}].to_set,
                  @json[:tech_contacts].to_set)
   end
 


### PR DESCRIPTION
Now the response should also return email. This change also adds the same field to registry lock API now, but it as an addition, there should be no problems with implementing that.