### PR TITLE
Add DNS keys to domain API response

### DIFF
--- a/doc/registrant-api/v1/domain.md
+++ b/doc/registrant-api/v1/domain.md
@@ -34,21 +34,25 @@ Content-Type: application/json
     "admin_contacts":[
       {
         "name":"John Smith",
-        "id":"62015e7d-42c8-4d68-8164-e9b71680fd95"
+        "id":"62015e7d-42c8-4d68-8164-e9b71680fd95",
+        "email": "john@email.com"
       },
       {
         "name":"William Smith",
-        "id":"a041c5b6-7772-4fac-83cd-fbce3b2c8867"
+        "id":"a041c5b6-7772-4fac-83cd-fbce3b2c8867",
+        "email": "william@email.com"
       }
     ],
     "tech_contacts":[
       {
         "name":"John Smith",
-        "id":"62015e7d-42c8-4d68-8164-e9b71680fd95"
+        "id":"62015e7d-42c8-4d68-8164-e9b71680fd95",
+        "email": "john@email.com"
       },
       {
         "name":"William Smith",
         "id":"a041c5b6-7772-4fac-83cd-fbce3b2c8867"
+        "email": "william@email.com"
       }
     ],
     "transfer_code":"98oiewslkfkd",
@@ -93,6 +97,10 @@ Content-Type: application/json
       },
 
     ],
+    "dnssec_keys": [
+      "257 3 13 KlHFYV42UtxC7LpsolDpoUZ9DNPDRYQypalBRIqlubBg/zg78aqciLk+NaWUbrkN7AUaM7h7tx91sLN+ORVPxA==",
+    ],
+    "dnssec_changed_at": "2015-09-09T09:11:14.860Z",
     "status_notes":{
 
     },
@@ -205,6 +213,10 @@ Content-Type: application/json
       },
 
     ],
+    "dnssec_keys": [
+      "257 3 13 KlHFYV42UtxC7LpsolDpoUZ9DNPDRYQypalBRIqlubBg/zg78aqciLk+NaWUbrkN7AUaM7h7tx91sLN+ORVPxA==",
+    ],
+    "dnssec_changed_at": "2015-09-09T09:11:14.860Z",
     "status_notes":{
 
     },
@@ -308,6 +320,10 @@ Content-Type: application/json
       ]
     }
   ],
+  "dnssec_keys": [
+      "257 3 13 KlHFYV42UtxC7LpsolDpoUZ9DNPDRYQypalBRIqlubBg/zg78aqciLk+NaWUbrkN7AUaM7h7tx91sLN+ORVPxA==",
+    ],
+  "dnssec_changed_at": "2015-09-09T09:11:14.860Z",
   "status_notes":{
 
   },

--- a/lib/serializers/registrant_api/domain.rb
+++ b/lib/serializers/registrant_api/domain.rb
@@ -43,7 +43,7 @@ module Serializers
           status_notes: domain.status_notes,
           nameservers: nameservers,
           dnssec_keys: dnssec_keys,
-          dnssec_changed_at: dnssec_updated_at
+          dnssec_changed_at: dnssec_updated_at,
         }
       end
 

--- a/lib/serializers/registrant_api/domain.rb
+++ b/lib/serializers/registrant_api/domain.rb
@@ -42,10 +42,22 @@ module Serializers
           locked_by_registrant_at: domain.locked_by_registrant_at,
           status_notes: domain.status_notes,
           nameservers: nameservers,
+          dnssec_keys: dnssec_keys,
+          dnssec_changed_at: dnssec_updated_at
         }
       end
 
       private
+
+      def dnssec_keys
+        domain.dnskeys.map do |key|
+          "#{key.flags} #{key.protocol} #{key.alg} #{key.public_key}"
+        end
+      end
+
+      def dnssec_updated_at
+        domain.dnskeys.order(updated_at: :desc).select(:updated_at).first
+      end
 
       def contacts(type)
         contact_pool = begin

--- a/test/integration/api/registrant/registrant_api_domains_test.rb
+++ b/test/integration/api/registrant/registrant_api_domains_test.rb
@@ -29,7 +29,11 @@ class RegistrantApiDomainsTest < ApplicationIntegrationTest
                    email: 'john@inbox.test'}],
                  domain[:tech_contacts])
     assert_equal({ name: 'Good Names', website: nil }, domain[:registrar])
+
     assert_equal([], domain[:nameservers])
+    assert_equal([], domain[:dnssec_keys])
+    assert(domain.has_key?(:dnssec_changed_at))
+
     assert(domain.has_key?(:locked_by_registrant_at))
   end
 


### PR DESCRIPTION
It is fairly similar to what we do for WHOIS records, but one query is slightly rewritten with removal of try-catch block.

You can safely ignore the code climate issue, it says that the issue has been fixed and then appeared again, exactly the same issue, I have not touched it.