### PR TITLE
Pass additional fields of Customer to Directo

### DIFF
--- a/app/models/concerns/invoice/book_keeping.rb
+++ b/app/models/concerns/invoice/book_keeping.rb
@@ -5,7 +5,7 @@ module Concerns
 
       def as_directo_json
         invoice = ActiveSupport::JSON.decode(ActiveSupport::JSON.encode(self))
-        invoice['customer_code'] = buyer.accounting_customer_code
+        invoice['customer'] = compose_directo_customer
         invoice['issue_date'] = issue_date.strftime('%Y-%m-%d')
         invoice['transaction_date'] = account_activity
                                       .bank_transaction&.paid_at&.strftime('%Y-%m-%d')
@@ -20,6 +20,14 @@ module Concerns
            'quantity': 1, 'price': ActionController::Base.helpers.number_with_precision(
              subtotal, precision: 2, separator: '.'
            ) }].as_json
+      end
+
+      def compose_directo_customer
+        {
+          'code': buyer.accounting_customer_code,
+          'destination': buyer_country_code,
+          'vat_reg_no': buyer_vat_no,
+        }.as_json
       end
     end
   end

--- a/app/models/concerns/registrar/book_keeping.rb
+++ b/app/models/concerns/registrar/book_keeping.rb
@@ -12,7 +12,7 @@ module Concerns
 
         invoice = {
           'number': 1,
-          'customer_code': accounting_customer_code,
+          'customer': compose_directo_customer,
           'language': language == 'en' ? 'ENG' : '', 'currency': activities.first.currency,
           'date': month.end_of_month.strftime('%Y-%m-%d')
         }.as_json
@@ -107,6 +107,14 @@ module Concerns
           'price': total,
           'unit': en ? 'pc' : 'tk',
         }
+      end
+
+      def compose_directo_customer
+        {
+          'code': accounting_customer_code,
+          'destination': address_country_code,
+          'vat_reg_no': vat_no,
+        }.as_json
       end
 
       def load_price(account_activity)

--- a/test/jobs/directo_invoice_forward_job_test.rb
+++ b/test/jobs/directo_invoice_forward_job_test.rb
@@ -14,6 +14,15 @@ class DirectoInvoiceForwardJobTest < ActiveSupport::TestCase
     Setting.directo_monthly_number_last = 309901
   end
 
+  def test_directo_json_sends_customer_as_hash
+    @invoice.update!(buyer_country_code: @user.address_country_code)
+
+    json_output = @invoice.as_directo_json
+    assert json_output['customer'].is_a? Hash
+    assert_equal @user.accounting_customer_code, json_output['customer']['code']
+    assert_equal @user.address_country_code, json_output['customer']['destination']
+  end
+
   def test_xml_is_include_transaction_date
     @invoice.update(total: @invoice.account_activity.bank_transaction.sum)
     @invoice.account_activity.bank_transaction.update(paid_at: Time.zone.now)


### PR DESCRIPTION
Closes #1647 

From the last update, in Directo gem, VATCode is determined inside the gem based on Customer (Registrar) country code.

As we submitted only CustomerCode (without destination country) to Directo gem, we couldn't find the right value for VATCode, which in this case failsafes to 0 (no vat).

Please test with Directo Sandbox to see if it eats the new format, as there are some additional fields submitted.