### PR TITLE
CRL Update decoupiling

### DIFF
--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -132,12 +132,16 @@ class Certificate < ApplicationRecord
   end
 
   class << self
+
+    def tostdout(message)
+      time = Time.zone.now.utc
+      STDOUT << "#{time} - #{message}\n" unless Rails.env.test?
+    end
     def update_crl
-      start = "#{Time.zone.now.utc} - Running crlupdater\n"
-      stop = "#{Time.zone.now.utc} - Finished running crlupdater\n"
-      STDOUT << start unless Rails.env.test?
+
+      tostdout('Running crlupdater')
       system('/bin/bash', ENV['crl_updater_path'].to_s)
-      STDOUT << stop unless Rails.env.test?
+      tostdout('Finished running crlupdater')
     end
 
     def parse_md_from_string(crt)

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -134,7 +134,7 @@ class Certificate < ApplicationRecord
   class << self
     def update_crl
       STDOUT << "#{Time.zone.now.utc} - Running crlupdater\n" unless Rails.env.test?
-      system "#{ENV['crl_updater_path']}"
+      system('/bin/bash', ENV['crl_updater_path'].to_s)
       STDOUT << "#{Time.zone.now.utc} - Finished running crlupdater\n" unless Rails.env.test?
     end
 

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -132,13 +132,12 @@ class Certificate < ApplicationRecord
   end
 
   class << self
-
     def tostdout(message)
       time = Time.zone.now.utc
       STDOUT << "#{time} - #{message}\n" unless Rails.env.test?
     end
-    def update_crl
 
+    def update_crl
       tostdout('Running crlupdater')
       system('/bin/bash', ENV['crl_updater_path'].to_s)
       tostdout('Finished running crlupdater')

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -127,82 +127,15 @@ class Certificate < ApplicationRecord
       return false
     end
 
-    self.class.update_registry_crl
-    self.class.reload_apache
+    self.class.update_crl
     self
   end
 
   class << self
     def update_crl
-#      update_id_crl
-#      update_registry_crl
-#      reload_apache
-      run_crlupdater
-    end
-    def run_crlupdater
       STDOUT << "#{Time.zone.now.utc} - Running crlupdater\n" unless Rails.env.test?
-      system "#{ENV['crl_update_path']}"
+      system "#{ENV['crl_updater_path']}"
       STDOUT << "#{Time.zone.now.utc} - Finished running crlupdater\n" unless Rails.env.test?
-    end
-    def update_id_crl
-      STDOUT << "#{Time.zone.now.utc} - Updating ID CRL\n" unless Rails.env.test?
-
-      _out, _err, _st = Open3.capture3("
-        mkdir -p #{ENV['crl_dir']}/crl-id-temp
-        cd #{ENV['crl_dir']}/crl-id-temp
-
-        wget https://sk.ee/crls/esteid/esteid2007.crl
-        wget https://sk.ee/crls/juur/crl.crl
-        wget https://sk.ee/crls/eeccrca/eeccrca.crl
-        wget https://sk.ee/repository/crls/esteid2011.crl
-
-        openssl crl -in esteid2007.crl -out esteid2007.crl -inform DER
-        openssl crl -in crl.crl -out crl.crl -inform DER
-        openssl crl -in eeccrca.crl -out eeccrca.crl -inform DER
-        openssl crl -in esteid2011.crl -out esteid2011.crl -inform DER
-
-        ln -s crl.crl `openssl crl -hash -noout -in crl.crl`.r0
-        ln -s esteid2007.crl `openssl crl -hash -noout -in esteid2007.crl`.r0
-        ln -s eeccrca.crl `openssl crl -hash -noout -in eeccrca.crl`.r0
-        ln -s esteid2011.crl `openssl crl -hash -noout -in esteid2011.crl`.r0
-
-        rm -rf #{ENV['crl_dir']}/*.crl #{ENV['crl_dir']}/*.r0
-
-        mv #{ENV['crl_dir']}/crl-id-temp/* #{ENV['crl_dir']}
-
-        rm -rf #{ENV['crl_dir']}/crl-id-temp
-      ")
-
-      STDOUT << "#{Time.zone.now.utc} - ID CRL updated\n" unless Rails.env.test?
-    end
-
-    def update_registry_crl
-      STDOUT << "#{Time.zone.now.utc} - Updating registry CRL\n" unless Rails.env.test?
-
-      _out, _err, _st = Open3.capture3("
-        mkdir -p #{ENV['crl_dir']}/crl-temp
-        cd #{ENV['crl_dir']}/crl-temp
-
-        openssl ca -config #{ENV['openssl_config_path']} -keyfile #{ENV['ca_key_path']} -cert \
-        #{ENV['ca_cert_path']} -gencrl -out #{ENV['crl_dir']}/crl-temp/crl.pem -key \
-        '#{ENV['ca_key_password']}' -batch
-
-        ln -s crl.pem `openssl crl -hash -noout -in crl.pem`.r1
-
-        rm -rf #{ENV['crl_dir']}/*.pem #{ENV['crl_dir']}/*.r1
-
-        mv #{ENV['crl_dir']}/crl-temp/* #{ENV['crl_dir']}
-
-        rm -rf #{ENV['crl_dir']}/crl-temp
-      ")
-
-      STDOUT << "#{Time.zone.now.utc} - Registry CRL updated\n" unless Rails.env.test?
-    end
-
-    def reload_apache
-      STDOUT << "#{Time.zone.now.utc} - Reloading apache\n" unless Rails.env.test?
-      _out, _err, _st = Open3.capture3("sudo /etc/init.d/apache2 reload")
-      STDOUT << "#{Time.zone.now.utc} - Apache reloaded\n" unless Rails.env.test?
     end
 
     def parse_md_from_string(crt)

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -134,11 +134,16 @@ class Certificate < ApplicationRecord
 
   class << self
     def update_crl
-      update_id_crl
-      update_registry_crl
-      reload_apache
+#      update_id_crl
+#      update_registry_crl
+#      reload_apache
+      run_crlupdater
     end
-
+    def run_crlupdater
+      STDOUT << "#{Time.zone.now.utc} - Running crlupdater\n" unless Rails.env.test?
+      system "#{ENV['crl_update_path']}"
+      STDOUT << "#{Time.zone.now.utc} - Finished running crlupdater\n" unless Rails.env.test?
+    end
     def update_id_crl
       STDOUT << "#{Time.zone.now.utc} - Updating ID CRL\n" unless Rails.env.test?
 

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -133,9 +133,11 @@ class Certificate < ApplicationRecord
 
   class << self
     def update_crl
-      STDOUT << "#{Time.zone.now.utc} - Running crlupdater\n" unless Rails.env.test?
+      start = "#{Time.zone.now.utc} - Running crlupdater\n"
+      stop = "#{Time.zone.now.utc} - Finished running crlupdater\n"
+      STDOUT << start unless Rails.env.test?
       system('/bin/bash', ENV['crl_updater_path'].to_s)
-      STDOUT << "#{Time.zone.now.utc} - Finished running crlupdater\n" unless Rails.env.test?
+      STDOUT << stop unless Rails.env.test?
     end
 
     def parse_md_from_string(crt)

--- a/config/application.yml.sample
+++ b/config/application.yml.sample
@@ -34,6 +34,7 @@ time_zone: 'Tallinn' # more zones by rake time:zones:all
 openssl_config_path: '/etc/ssl/openssl.cnf'
 crl_dir:     '/home/registry/registry/shared/ca/crl'
 crl_path:     '/home/registry/registry/shared/ca/crl/crl.pem'
+crl_updater_path: '/home/registry/registry/shared/ca/crl/crlupdater.sh'
 ca_cert_path: '/home/registry/registry/shared/ca/certs/ca.crt.pem'
 ca_key_path:  '/home/registry/registry/shared/ca/private/ca.key.pem'
 ca_key_password: 'your-root-key-password'


### PR DESCRIPTION
CRL updating is very env specific thing and i think our current approach where we handle it in application code is far from ideal.
I introduced new configuration variable crl_updater_path what should point to script what handles crl refreshing/updating.