### PR TITLE
Set dnssec keys to empty array when generating zone whois

### DIFF
--- a/app/models/concerns/zone/whois_queryable.rb
+++ b/app/models/concerns/zone/whois_queryable.rb
@@ -31,12 +31,14 @@ module Concerns
         data
       end
 
+      # Take note - since this concern only used to zone whois queries, dnssec keys are set to
+      # empty array
       def domain_vars
         { disclaimer: Setting.registry_whois_disclaimer, name: origin,
           registered: created_at.try(:to_s, :iso8601), status: ['ok (paid and in zone)'],
           changed: updated_at.try(:to_s, :iso8601), email: Setting.registry_email,
           admin_contacts: [contact_vars], tech_contacts: [contact_vars],
-          nameservers: nameserver_vars }
+          nameservers: nameserver_vars, dnssec_keys: [], dnssec_changed: nil }
       end
 
       def registrar_vars

--- a/test/jobs/regenerate_subzone_whoises_job_test.rb
+++ b/test/jobs/regenerate_subzone_whoises_job_test.rb
@@ -12,7 +12,10 @@ class RegenerateSubzoneWhoisesJobTest < ActiveSupport::TestCase
     assert_nil Whois::Record.find_by(name: dns_zones(:one).origin)
 
     RegenerateSubzoneWhoisesJob.run
-    assert Whois::Record.find_by(name: subzone.origin)
+    record = Whois::Record.find_by(name: subzone.origin)
+    assert record
+    assert record.json['dnssec_keys'].is_a?(Array)
+
     assert_nil Whois::Record.find_by(name: dns_zones(:one).origin)
   end
 end


### PR DESCRIPTION
Closes #1665 

After deploy we should run `RegenerateSubzoneWhoisesJob.run` from the application console to regenerate zones WHOIS info.