### PR TITLE
Send each registrar's monthly summary to Directo separately

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 
 GIT
   remote: https://github.com/internetee/directo.git
-  revision: 8ff8a382d004ffb85722a6a7a68a020bd4d7159b
+  revision: e4ba54f601d1815fd8782a196788730d47861e86
   branch: master
   specs:
     directo (1.0.1)
@@ -165,7 +165,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     countries (3.0.1)
       i18n_data (~> 0.10.0)
       sixarm_ruby_unaccent (~> 1.1)
@@ -241,7 +241,7 @@ GEM
     httpi (2.4.4)
       rack
       socksify
-    i18n (1.8.3)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     i18n_data (0.10.0)
     isikukood (0.1.2)

--- a/app/jobs/directo_invoice_forward_job.rb
+++ b/app/jobs/directo_invoice_forward_job.rb
@@ -32,12 +32,15 @@ class DirectoInvoiceForwardJob < Que::Job
       next unless registrar.cash_account
 
       @client = new_directo_client
-      summary = registrar.monthly_summary(month: @month)
-      @client.invoices.add_with_schema(invoice: summary, schema: 'summary') unless summary.nil?
-      next unless @client.invoices.count.positive?
-
-      sync_with_directo
+      send_invoice_for_registrar(registrar)
     end
+  end
+
+  def send_invoice_for_registrar(registrar)
+    summary = registrar.monthly_summary(month: @month)
+    @client.invoices.add_with_schema(invoice: summary, schema: 'summary') unless summary.nil?
+
+    sync_with_directo if @client.invoices.count.positive?
   end
 
   def assign_monthly_numbers

--- a/test/jobs/directo_invoice_forward_job_test.rb
+++ b/test/jobs/directo_invoice_forward_job_test.rb
@@ -151,4 +151,42 @@ class DirectoInvoiceForwardJobTest < ActiveSupport::TestCase
       DirectoInvoiceForwardJob.run(monthly: true, dry: false)
     end
   end
+
+  def test_sends_each_monthly_invoice_separately
+    activity = account_activities(:one)
+    price = billing_prices(:create_one_year)
+    price.update(duration: '3 years')
+    activity.update(activity_type: 'create', price: price)
+
+    # Creating account activity for second action
+    another_activity = activity.dup
+    another_activity.account = accounts(:two)
+
+    AccountActivity.skip_callback(:create, :after, :update_balance)
+    another_activity.created_at = Time.zone.parse('2010-07-05 10:00')
+    another_activity.save
+    AccountActivity.set_callback(:create, :after, :update_balance)
+
+    response = <<-XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <results>
+      <Result Type="0" Desc="OK" docid="309902" doctype="ARVE" submit="Invoices"/>
+    </results>
+    XML
+
+    first_registrar_stub = stub_request(:post, ENV['directo_invoice_url']).with do |request|
+      body = CGI.unescape(request.body)
+      (body.include? 'StartDate') && (body.include? 'EndDate') && (body.include? 'bestnames')
+    end.to_return(status: 200, body: response)
+
+    second_registrar_stub = stub_request(:post, ENV['directo_invoice_url']).with do |request|
+      body = CGI.unescape(request.body)
+      (body.include? 'StartDate') && (body.include? 'EndDate') && (body.include? 'goodnames')
+    end.to_return(status: 200, body: response)
+
+    DirectoInvoiceForwardJob.run(monthly: true, dry: false)
+
+    assert_requested first_registrar_stub
+    assert_requested second_registrar_stub
+  end
 end

--- a/test/jobs/directo_invoice_forward_job_test.rb
+++ b/test/jobs/directo_invoice_forward_job_test.rb
@@ -153,6 +153,8 @@ class DirectoInvoiceForwardJobTest < ActiveSupport::TestCase
   end
 
   def test_sends_each_monthly_invoice_separately
+    WebMock.reset!
+
     activity = account_activities(:one)
     price = billing_prices(:create_one_year)
     price.update(duration: '3 years')


### PR DESCRIPTION
As it turns out, when sending large requests to Directo, it might take up to 10 minutes before getting answer from API. By new design we're going to send each registrar's monthly summary separately to decrease request's payload size.

Fixes https://github.com/internetee/registry/issues/1600