### PR TITLE
Always generate reference number of length 7

### DIFF
--- a/app/models/bank_transaction.rb
+++ b/app/models/bank_transaction.rb
@@ -121,7 +121,8 @@ class BankTransaction < ApplicationRecord
   end
 
   def ref_number_from_description
-    match_data = /(\d{7})/.match(description)
-    match_data[0] if match_data.present?
+    (Billing::ReferenceNo::MULTI_REGEXP.match(description) || []).captures.each do |match|
+      break match if match.length == 7 || Registrar.where(reference_no: match).present?
+    end
   end
 end

--- a/app/models/bank_transaction.rb
+++ b/app/models/bank_transaction.rb
@@ -118,7 +118,11 @@ class BankTransaction < ApplicationRecord
 
   def ref_number_from_description
     (Billing::ReferenceNo::MULTI_REGEXP.match(description) || []).captures.each do |match|
-      break match if match.length == 7 || Billing::ReferenceNo.valid?(match)
+      break match if match.length == 7 || valid_ref_no?(match)
     end
+  end
+
+  def valid_ref_no?(match)
+    return true if Billing::ReferenceNo.valid?(match) && Registrar.find_by(reference_no: match).any?
   end
 end

--- a/app/models/bank_transaction.rb
+++ b/app/models/bank_transaction.rb
@@ -118,7 +118,7 @@ class BankTransaction < ApplicationRecord
 
   def ref_number_from_description
     (Billing::ReferenceNo::MULTI_REGEXP.match(description) || []).captures.each do |match|
-      break match if match.length == 7 || Registrar.where(reference_no: match).present?
+      break match if match.length == 7 || Billing::ReferenceNo.valid?(match)
     end
   end
 end

--- a/app/models/bank_transaction.rb
+++ b/app/models/bank_transaction.rb
@@ -38,11 +38,7 @@ class BankTransaction < ApplicationRecord
     return unless invoice
     return unless invoice.payable?
 
-    channel = if manual
-                'admin_payment'
-              else
-                'system_payment'
-              end
+    channel = manual ? 'admin_payment' : 'system_payment'
     create_internal_payment_record(channel: channel, invoice: invoice,
                                    registrar: registrar)
   end

--- a/app/models/billing/reference_no.rb
+++ b/app/models/billing/reference_no.rb
@@ -1,7 +1,7 @@
 module Billing
   class ReferenceNo
-    REGEXP = /\A\d{2,20}\z/
-    MULTI_REGEXP = /(\d{2,20})/
+    REGEXP = /\A\d{2,20}\z/.freeze
+    MULTI_REGEXP = /(\d{2,20})/.freeze
 
     def self.generate
       base = Base.generate

--- a/app/models/billing/reference_no.rb
+++ b/app/models/billing/reference_no.rb
@@ -7,5 +7,10 @@ module Billing
       base = Base.generate
       "#{base}#{base.check_digit}"
     end
+
+    def self.valid?(ref)
+      base = Base.new(ref.to_s[0...-1])
+      ref.to_s == "#{base}#{base.check_digit}"
+    end
   end
 end

--- a/app/models/billing/reference_no.rb
+++ b/app/models/billing/reference_no.rb
@@ -1,6 +1,7 @@
 module Billing
   class ReferenceNo
     REGEXP = /\A\d{2,20}\z/
+    MULTI_REGEXP = /(\d{2,20})/
 
     def self.generate
       base = Base.generate

--- a/app/models/billing/reference_no/base.rb
+++ b/app/models/billing/reference_no/base.rb
@@ -2,7 +2,7 @@ module Billing
   class ReferenceNo
     class Base
       def self.generate
-        new(SecureRandom.random_number(1..1_000_000))
+        new((SecureRandom.random_number(9e5) + 1e5).to_i)
       end
 
       def initialize(base)


### PR DESCRIPTION
From now on, `Billing::ReferenceNo.generate `always returns valid reference number with length of 7.

As there are already some registrars with generated `reference_no` shorter than 7, `ref_number_from_description` now respects them as well, by searching for numbers that end with correct reference check code