### PR TITLE
Registrant: Query representable and other related contacts conditionally

### DIFF
--- a/app/controllers/api/v1/registrant/contacts_controller.rb
+++ b/app/controllers/api/v1/registrant/contacts_controller.rb
@@ -91,7 +91,7 @@ module Api
         private
 
         def current_user_contacts
-          current_registrant_user.contacts
+          current_registrant_user.contacts(representable: false)
         rescue CompanyRegister::NotAvailableError
           current_registrant_user.direct_contacts
         end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -210,10 +210,13 @@ class Contact < ApplicationRecord
       )
     end
 
-    def registrant_user_contacts(registrant_user)
-      registrant_user_direct_contacts(registrant_user)
-        .or(registrant_user_company_contacts(registrant_user))
-        .or(registrant_user_indirect_contacts(registrant_user))
+    def registrant_user_contacts(registrant_user, representment: true)
+      represented_contacts = registrant_user_direct_contacts(registrant_user)
+                             .or(registrant_user_company_contacts(registrant_user))
+
+      return represented_contacts if representment
+
+      represented_contacts.or(registrant_user_indirect_contacts(registrant_user))
     end
 
     def registrant_user_direct_contacts(registrant_user)

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -210,11 +210,11 @@ class Contact < ApplicationRecord
       )
     end
 
-    def registrant_user_contacts(registrant_user, representment: true)
+    def registrant_user_contacts(registrant_user, representable: true)
       represented_contacts = registrant_user_direct_contacts(registrant_user)
                              .or(registrant_user_company_contacts(registrant_user))
 
-      return represented_contacts if representment
+      return represented_contacts if representable
 
       represented_contacts.or(registrant_user_indirect_contacts(registrant_user))
     end

--- a/app/models/registrant_user.rb
+++ b/app/models/registrant_user.rb
@@ -22,8 +22,8 @@ class RegistrantUser < User
                                            citizen_country_code: country.alpha3)
   end
 
-  def contacts(representment: true)
-    Contact.registrant_user_contacts(self, representment: representment)
+  def contacts(representable: true)
+    Contact.registrant_user_contacts(self, representable: representable)
   end
 
   def direct_contacts

--- a/app/models/registrant_user.rb
+++ b/app/models/registrant_user.rb
@@ -22,8 +22,8 @@ class RegistrantUser < User
                                            citizen_country_code: country.alpha3)
   end
 
-  def contacts
-    Contact.registrant_user_contacts(self)
+  def contacts(representment: true)
+    Contact.registrant_user_contacts(self, representment: representment)
   end
 
   def direct_contacts

--- a/test/fixtures/contacts.yml
+++ b/test/fixtures/contacts.yml
@@ -78,6 +78,18 @@ identical_to_william:
   auth_info: 5ab865
   uuid: c0a191d5-3793-4f0b-8f85-491612d0293e
 
+registrar_ltd:
+  name: Registrar Ltd
+  email: registrar@inbox.test
+  phone: '+555.555'
+  ident: 1234567890
+  ident_type: org
+  registrar: goodnames
+  ident_country_code: US
+  code: registrarltd-001
+  auth_info: e2c441
+  uuid: 28b65455-6f1a-49fd-961c-0758886dbd76
+
 invalid:
   name: any
   code: invalid

--- a/test/integration/api/registrant/registrant_api_contacts_test.rb
+++ b/test/integration/api/registrant/registrant_api_contacts_test.rb
@@ -12,7 +12,7 @@ class RegistrantApiContactsTest < ApplicationIntegrationTest
 
   def test_root_accepts_limit_and_offset_parameters
     contacts(:william).update!(ident: '1234', ident_type: 'priv', ident_country_code: 'US')
-    assert_equal 4, @user.contacts.size
+    assert_equal 4, @user.contacts(representable: false).size
 
     get '/api/v1/registrant/contacts', params: { 'limit' => 1, 'offset' => 0 },
         headers: @auth_headers
@@ -22,7 +22,7 @@ class RegistrantApiContactsTest < ApplicationIntegrationTest
 
     get '/api/v1/registrant/contacts', headers: @auth_headers
     response_json = JSON.parse(response.body, symbolize_names: true)
-    assert_equal(@user.contacts.size, response_json.count)
+    assert_equal(@user.contacts(representable: false).size, response_json.count)
   end
 
   def test_get_contact_details_by_uuid

--- a/test/integration/api/v1/registrant/contacts/list_test.rb
+++ b/test/integration/api/v1/registrant/contacts/list_test.rb
@@ -35,7 +35,7 @@ class RegistrantApiV1ContactListTest < ActionDispatch::IntegrationTest
     get api_v1_registrant_contacts_path, as: :json, headers: { 'HTTP_AUTHORIZATION' => auth_token }
 
     response_json = JSON.parse(response.body, symbolize_names: true)
-    assert_equal @user.contacts.count, response_json.size
+    assert_equal @user.contacts(representable: false).count, response_json.size
     assert_includes response_json.map{ |hash| hash[:code] }, @contact.code
   end
 

--- a/test/system/registrant_area/domains/list_test.rb
+++ b/test/system/registrant_area/domains/list_test.rb
@@ -28,6 +28,20 @@ class RegistrantAreaDomainListTest < ApplicationSystemTestCase
     assert_no_text 'metro.test'
   end
 
+  def test_only_shows_direct_relation_and_or_company_domains
+    # case https://github.com/internetee/registry/issues/1690
+    tech_contact = contacts(:registrar_ltd)
+
+    # All domains share the same tech contact object
+    Domain.all.each do |domain|
+      DomainContact.create(domain: domain, contact: tech_contact, type: TechDomainContact)
+    end
+
+    visit registrant_domains_url
+    assert_no_text 'Company register is unavailable.'
+    assert_no_text 'metro.test'
+  end
+
   def test_notification_when_company_register_is_unavailable
     CompanyRegister::Client.stub(:new, CompanyRegisterClientStub.new) do
       visit registrant_domains_url


### PR DESCRIPTION
Closes #1690

Makes it possible to query all related contacts for registrant user conditionally, depending on whether we need to access representable contacts (with specific ident code of registrant, company contacts that are juridically represtentable by registrant) or all that are in relation to domains accessible by registrant.