### PR TITLE
Localize whois record disclaimer

### DIFF
--- a/db/data/20201007104651_make_whois_disclamer_i18ned.rb
+++ b/db/data/20201007104651_make_whois_disclamer_i18ned.rb
@@ -1,0 +1,21 @@
+class MakeWhoisDisclamerI18ned < ActiveRecord::Migration[6.0]
+  def up
+    entry = SettingEntry.find_by(code: 'registry_whois_disclaimer')
+    hash = { en: 'Search results may not be used for commercial, advertising, recompilation, repackaging, redistribution, reuse, obscuring or other similar activities.',
+             et: 'Otsitulemusi ei tohi kasutada ärilistel, reklaami, ümber töötlemise, edasi levitamise, taaskasutuse, muutmise ega muul sarnasel eesmärgil.',
+             ru: 'Результаты поиска не могут быть использованы в коммерческих целях, включая, но не ограничиваясь, рекламу, рекомпиляцию, изменение формата, перераспределение либо переиспользование.' }
+    string = JSON.generate(hash)
+    entry.format = 'hash'
+    entry.value = string
+    entry.save!
+  end
+
+  def down
+    entry = SettingEntry.find_by(code: 'registry_whois_disclaimer')
+    string = 'Search results may not be used for commercial, advertising, recompilation, \
+              repackaging, redistribution, reuse, obscuring or other similar activities.'
+    entry.format = 'string'
+    entry.value = string
+    entry.save!
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20200901131427)
+DataMigrate::Data.define(version: 20201007104651)

--- a/test/fixtures/setting_entries.yml
+++ b/test/fixtures/setting_entries.yml
@@ -448,10 +448,9 @@ dispute_period_in_months:
 
 registry_whois_disclaimer:
   code: registry_whois_disclaimer
-  value: 'Search results may not be used for commercial, advertising, recompilation,
-    repackaging, redistribution, reuse, obscuring or other similar activities.'
+  value: "{\"en\":\"111\",\"et\":\"222\",\"ru\":\"333\"}"
   group: contacts
-  format: string
+  format: hash
   created_at: <%= Time.zone.parse('2010-07-05') %>
   updated_at: <%= Time.zone.parse('2010-07-05') %>
 

--- a/test/models/whois/record_test.rb
+++ b/test/models/whois/record_test.rb
@@ -8,7 +8,7 @@ class Whois::RecordTest < ActiveSupport::TestCase
     @auction = auctions(:one)
 
     @original_disclaimer = Setting.registry_whois_disclaimer
-    Setting.registry_whois_disclaimer = 'disclaimer'
+    Setting.registry_whois_disclaimer = JSON.generate({en: 'disclaimer'})
   end
 
   teardown do
@@ -16,8 +16,8 @@ class Whois::RecordTest < ActiveSupport::TestCase
   end
 
   def test_reads_disclaimer_setting
-    Setting.registry_whois_disclaimer = 'test disclaimer'
-    assert_equal 'test disclaimer', Whois::Record.disclaimer
+    Setting.registry_whois_disclaimer = JSON.generate({en: 'test_disclaimer'})
+    assert_equal Setting.registry_whois_disclaimer, Whois::Record.disclaimer
   end
 
   def test_updates_whois_record_from_auction_when_started
@@ -28,7 +28,7 @@ class Whois::RecordTest < ActiveSupport::TestCase
 
     assert_equal ({ 'name' => 'domain.test',
                     'status' => ['AtAuction'],
-                    'disclaimer' => 'disclaimer' }), @whois_record.json
+                    'disclaimer' => { 'en' => 'disclaimer' }}), @whois_record.json
   end
 
   def test_updates_whois_record_from_auction_when_no_bids
@@ -49,7 +49,7 @@ class Whois::RecordTest < ActiveSupport::TestCase
 
     assert_equal ({ 'name' => 'domain.test',
                     'status' => ['PendingRegistration'],
-                    'disclaimer' => 'disclaimer',
+                    'disclaimer' => { 'en' => 'disclaimer' },
                     'registration_deadline' => registration_deadline.try(:to_s, :iso8601) }),
                  @whois_record.json
   end
@@ -64,7 +64,7 @@ class Whois::RecordTest < ActiveSupport::TestCase
 
     assert_equal ({ 'name' => 'domain.test',
                     'status' => ['PendingRegistration'],
-                    'disclaimer' => 'disclaimer',
+                    'disclaimer' => { 'en' => 'disclaimer' },
                     'registration_deadline' => registration_deadline.try(:to_s, :iso8601) }),
                  @whois_record.json
   end

--- a/test/models/whois_record_test.rb
+++ b/test/models/whois_record_test.rb
@@ -12,10 +12,7 @@ class WhoisRecordTest < ActiveSupport::TestCase
   end
 
   def test_generated_json_has_expected_values
-    expected_disclaimer_text = <<-TEXT.squish
-    Search results may not be used for commercial, advertising, recompilation,
-    repackaging, redistribution, reuse, obscuring or other similar activities.
-    TEXT
+    expected_disclaimer_text = SettingEntry.find_by(code: 'registry_whois_disclaimer').retrieve
 
     expected_partial_hash = {
       disclaimer: expected_disclaimer_text,


### PR DESCRIPTION
Closes #1703 

Related to https://github.com/internetee/whois/pull/66 , must be tested/merged together.
After deploy:
1. Run data migrations as `rake data:migrate`.

1. Enqueue whois record updates as per `rake whois:regenerate`.

Make sure what data migrations and delayed jobs (que) are running.
