### PR TITLE
DomainCron: Don't send force delete mail if template empty

### DIFF
--- a/app/models/concerns/job/force_delete_notify.rb
+++ b/app/models/concerns/job/force_delete_notify.rb
@@ -15,7 +15,7 @@ module Concerns
           domain.registrar.notifications.create!(text: I18n.t('grace_period_started_domain',
                                                               domain_name: domain.name,
                                                               date: domain.force_delete_start))
-          send_mail(domain)
+          send_mail(domain) if domain.template_name.present?
           domain.update(contact_notification_sent_date: Time.zone.today)
         end
 


### PR DESCRIPTION
When soft force delete is scheduled in admin portal and _notify_ checkbox is not set, `template_name` for domain is `nil`. Apparently `DomainCron.start_client_hold` didn't respect that and still tried to send mail, which halted the _proceed client hold_ cycle as no mail template was found.