### PR TITLE
Registrant API: domain registrant confirmations

### DIFF
--- a/app/controllers/api/v1/registrant/confirms_controller.rb
+++ b/app/controllers/api/v1/registrant/confirms_controller.rb
@@ -1,0 +1,55 @@
+require 'serializers/registrant_api/domain'
+
+module Api
+  module V1
+    module Registrant
+      class ConfirmsController < ::Api::V1::Registrant::BaseController
+        skip_before_action :authenticate, :set_paper_trail_whodunnit
+        before_action :set_domain, only: %i[index update]
+        before_action :verify_updateable, only: %i[index update]
+
+        def index
+          render json: {
+            domain_name: @domain.name,
+            current_registrant: serialized_registrant(@domain.registrant),
+            new_registrant: serialized_registrant(@domain.pending_registrant)
+          }
+        end
+
+        def update
+        end
+
+        private
+
+        def serialized_registrant(registrant)
+          {
+            name: registrant.try(:name),
+            ident: registrant.try(:ident),
+            country: registrant.try(:ident_country_code)
+          }
+        end
+
+        def confirmation_params
+          params do |p|
+            p.require(:name)
+            p.require(:token)
+          end
+        end
+
+        def set_domain
+          @domain = Domain.find_by(name: confirmation_params[:name])
+          return if @domain
+
+          render json: { error: 'Domain not found' }, status: :not_found
+        end
+
+        def verify_updateable
+          return if @domain.registrant_update_confirmable?(confirmation_params[:token])
+
+          render json: { error: 'Application expired or not found' },
+          status: :unauthorized
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/registrant/confirms_controller.rb
+++ b/app/controllers/api/v1/registrant/confirms_controller.rb
@@ -26,11 +26,9 @@ module Api
             return
           end
 
-          render json: {
-            domain_name: @domain.name,
-            current_registrant: serialized_registrant(current_registrant),
-            status: params[:decision],
-          }
+          render json: { domain_name: @domain.name,
+                         current_registrant: serialized_registrant(current_registrant),
+                         status: params[:decision] }
         end
 
         private
@@ -96,11 +94,13 @@ module Api
         end
 
         def verify_action
-          if params[:template] == 'change'
-            return true if @domain.registrant_update_confirmable?(verify_params[:token])
-          elsif params[:template] == 'delete'
-            return true if @domain.registrant_delete_confirmable?(verify_params[:token])
-          end
+          action = if params[:template] == 'change'
+                     @domain.registrant_update_confirmable?(verify_params[:token])
+                   elsif params[:template] == 'delete'
+                     @domain.registrant_delete_confirmable?(verify_params[:token])
+                   end
+
+          return unless action
 
           render json: { error: 'Application expired or not found' }, status: :unauthorized
         end

--- a/app/controllers/api/v1/registrant/confirms_controller.rb
+++ b/app/controllers/api/v1/registrant/confirms_controller.rb
@@ -13,7 +13,7 @@ module Api
           render json: {
             domain_name: @domain.name,
             current_registrant: serialized_registrant(@domain.registrant),
-            new_registrant: serialized_registrant(@domain.pending_registrant)
+            new_registrant: serialized_registrant(@domain.pending_registrant),
           }
         end
 
@@ -26,7 +26,7 @@ module Api
           render json: {
             domain_name: @domain.name,
             current_registrant: serialized_registrant(current_registrant),
-            status: params[:decision]
+            status: params[:decision],
           }
         end
 
@@ -53,7 +53,7 @@ module Api
           {
             name: registrant.try(:name),
             ident: registrant.try(:ident),
-            country: registrant.try(:ident_country_code)
+            country: registrant.try(:ident_country_code),
           }
         end
 

--- a/app/controllers/api/v1/registrant/confirms_controller.rb
+++ b/app/controllers/api/v1/registrant/confirms_controller.rb
@@ -17,9 +17,22 @@ module Api
         end
 
         def update
+          verification = RegistrantVerification.new(domain_id: @domain.id,
+            verification_token: confirmation_params[:token])
+
+            head(update_action(verification) ? :ok : :bad_request)
         end
 
         private
+
+        def update_action(verification)
+          initiator = "email link, #{t(:user_not_authenticated)}"
+          if params[:confirm].present?
+            verification.domain_registrant_change_confirm!(initiator)
+          else
+            verification.domain_registrant_change_reject!(initiator)
+          end
+        end
 
         def serialized_registrant(registrant)
           {

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -10,6 +10,6 @@ class ApplicationMailer < ActionMailer::Base
     url ||= registrant_domain_update_confirm_url(domain, token: token)
     return url if base_url.blank?
 
-    "#{base_url}/confirms/#{domain.name_puny}/#{method}/#{token}"
+    "#{base_url}/confirmation/#{domain.name_puny}/#{method}/#{token}"
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,15 @@
 class ApplicationMailer < ActionMailer::Base
   append_view_path Rails.root.join('app', 'views', 'mailers')
   layout 'mailer'
+
+  def registrant_confirm_url(domain:, method:)
+    token = domain.registrant_verification_token
+    base_url = ENV['registrant_portal_verifications_base_url']
+
+    url = registrant_domain_delete_confirm_url(domain, token: token) if method == 'delete'
+    url ||= registrant_domain_update_confirm_url(domain, token: token)
+    return url if base_url.blank?
+
+    "#{base_url}/confirms/#{domain.name_puny}/#{method}/#{token}"
+  end
 end

--- a/app/mailers/domain_delete_mailer.rb
+++ b/app/mailers/domain_delete_mailer.rb
@@ -53,7 +53,12 @@ class DomainDeleteMailer < ApplicationMailer
   private
 
   def confirmation_url(domain)
-    registrant_domain_delete_confirm_url(domain, token: domain.registrant_verification_token)
+    base_url = ENV['registrant_portal_verifications_base_url']
+    if base_url.blank?
+      registrant_domain_delete_confirm_url(domain, token: domain.registrant_verification_token)
+    else
+      "#{base_url}/confirmation/#{domain.name_puny}/#{domain.registrant_verification_token}"
+    end
   end
 
   def forced_email_from

--- a/app/mailers/domain_delete_mailer.rb
+++ b/app/mailers/domain_delete_mailer.rb
@@ -6,7 +6,7 @@ class DomainDeleteMailer < ApplicationMailer
   def confirmation_request(domain:, registrar:, registrant:)
     @domain = DomainPresenter.new(domain: domain, view: view_context)
     @registrar = RegistrarPresenter.new(registrar: registrar, view: view_context)
-    @confirmation_url = confirmation_url(domain)
+    @confirmation_url = registrant_confirm_url(domain: domain, method: 'delete')
 
     subject = default_i18n_subject(domain_name: domain.name)
     mail(to: registrant.email, subject: subject)
@@ -51,15 +51,6 @@ class DomainDeleteMailer < ApplicationMailer
   end
 
   private
-
-  def confirmation_url(domain)
-    base_url = ENV['registrant_portal_verifications_base_url']
-    if base_url.blank?
-      registrant_domain_delete_confirm_url(domain, token: domain.registrant_verification_token)
-    else
-      "#{base_url}/confirmation/#{domain.name_puny}/delete/#{domain.registrant_verification_token}"
-    end
-  end
 
   def forced_email_from
     ENV['action_mailer_force_delete_from'] || self.class.default[:from]

--- a/app/mailers/domain_delete_mailer.rb
+++ b/app/mailers/domain_delete_mailer.rb
@@ -57,7 +57,7 @@ class DomainDeleteMailer < ApplicationMailer
     if base_url.blank?
       registrant_domain_delete_confirm_url(domain, token: domain.registrant_verification_token)
     else
-      "#{base_url}/confirmation/#{domain.name_puny}/#{domain.registrant_verification_token}"
+      "#{base_url}/confirmation/#{domain.name_puny}/delete/#{domain.registrant_verification_token}"
     end
   end
 

--- a/app/mailers/registrant_change_mailer.rb
+++ b/app/mailers/registrant_change_mailer.rb
@@ -50,7 +50,12 @@ class RegistrantChangeMailer < ApplicationMailer
   private
 
   def confirmation_url(domain)
-    registrant_domain_update_confirm_url(domain, token: domain.registrant_verification_token)
+    base_url = ENV['registrant_portal_verifications_base_url']
+    if base_url.blank?
+      registrant_domain_update_confirm_url(domain, token: domain.registrant_verification_token)
+    else
+      "#{base_url}/confirmation/#{domain.name_puny}/change/#{domain.registrant_verification_token}"
+    end
   end
 
   def address_processing

--- a/app/mailers/registrant_change_mailer.rb
+++ b/app/mailers/registrant_change_mailer.rb
@@ -5,7 +5,7 @@ class RegistrantChangeMailer < ApplicationMailer
     @domain = DomainPresenter.new(domain: domain, view: view_context)
     @registrar = RegistrarPresenter.new(registrar: registrar, view: view_context)
     @new_registrant = RegistrantPresenter.new(registrant: new_registrant, view: view_context)
-    @confirmation_url = confirmation_url(domain)
+    @confirmation_url = registrant_confirm_url(domain: domain, method: 'change')
 
     subject = default_i18n_subject(domain_name: domain.name)
     mail(to: current_registrant.email, subject: subject)
@@ -48,15 +48,6 @@ class RegistrantChangeMailer < ApplicationMailer
   end
 
   private
-
-  def confirmation_url(domain)
-    base_url = ENV['registrant_portal_verifications_base_url']
-    if base_url.blank?
-      registrant_domain_update_confirm_url(domain, token: domain.registrant_verification_token)
-    else
-      "#{base_url}/confirmation/#{domain.name_puny}/change/#{domain.registrant_verification_token}"
-    end
-  end
 
   def address_processing
     Contact.address_processing?

--- a/app/services/registrant_change.rb
+++ b/app/services/registrant_change.rb
@@ -5,6 +5,7 @@ class RegistrantChange
   end
 
   def confirm
+    Dispute.close_by_domain(@domain.name) if @domain.disputed?
     notify_registrant
   end
 

--- a/config/application.yml.sample
+++ b/config/application.yml.sample
@@ -87,6 +87,9 @@ sk_digi_doc_service_name: 'Testimine'
 registrant_api_base_url:
 registrant_api_auth_allowed_ips: '127.0.0.1, 0.0.0.0' #ips, separated with commas
 
+# Base URL (inc. https://) of REST registrant portal
+# Leave blank to use internal registrant portal
+registrant_portal_verifications_base_url: ''
 #
 # MISC
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,7 @@ Rails.application.routes.draw do
           resource :registry_lock, only: %i[create destroy]
         end
         resources :contacts, only: %i[index show update], param: :uuid
+        resources :companies, only: %i[index]
       end
 
       resources :auctions, only: %i[index show update], param: :uuid

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,12 +56,12 @@ Rails.application.routes.draw do
     namespace :v1 do
       namespace :registrant do
         post 'auth/eid', to: 'auth#eid'
-
+        get 'confirms/:name/:token', to: 'confirms#index', constraints: { name: /[^\/]+/ }
+        post 'confirms/:name/:token', to: 'confirms#update', constraints: { name: /[^\/]+/ }
         resources :domains, only: %i[index show], param: :uuid do
           resource :registry_lock, only: %i[create destroy]
         end
         resources :contacts, only: %i[index show update], param: :uuid
-        resources :companies, only: %i[index]
       end
 
       resources :auctions, only: %i[index show update], param: :uuid

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,8 +56,8 @@ Rails.application.routes.draw do
     namespace :v1 do
       namespace :registrant do
         post 'auth/eid', to: 'auth#eid'
-        get 'confirms/:name/:token', to: 'confirms#index', constraints: { name: /[^\/]+/ }
-        post 'confirms/:name/:token/:decision', to: 'confirms#update', constraints: { name: /[^\/]+/ }
+        get 'confirms/:name/:template/:token', to: 'confirms#index', constraints: { name: /[^\/]+/ }
+        post 'confirms/:name/:template/:token/:decision', to: 'confirms#update', constraints: { name: /[^\/]+/ }
 
         resources :domains, only: %i[index show], param: :uuid do
           resource :registry_lock, only: %i[create destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,7 +57,8 @@ Rails.application.routes.draw do
       namespace :registrant do
         post 'auth/eid', to: 'auth#eid'
         get 'confirms/:name/:token', to: 'confirms#index', constraints: { name: /[^\/]+/ }
-        post 'confirms/:name/:token', to: 'confirms#update', constraints: { name: /[^\/]+/ }
+        post 'confirms/:name/:token/:decision', to: 'confirms#update', constraints: { name: /[^\/]+/ }
+
         resources :domains, only: %i[index show], param: :uuid do
           resource :registry_lock, only: %i[create destroy]
         end

--- a/test/integration/api/registrant/registrant_api_verifications_test.rb
+++ b/test/integration/api/registrant/registrant_api_verifications_test.rb
@@ -1,0 +1,259 @@
+require 'test_helper'
+require 'auth_token/auth_token_creator'
+
+class RegistrantApiVerificationsTest < ApplicationIntegrationTest
+  def setup
+    super
+
+    @domain = domains(:hospital)
+    @registrant = @domain.registrant
+    @new_registrant = contacts(:jack)
+
+    @token = 'verysecrettoken'
+
+    @domain.update(statuses: [DomainStatus::PENDING_UPDATE],
+      registrant_verification_asked_at: Time.zone.now - 1.day,
+      registrant_verification_token: @token)
+
+  end
+
+  def test_fetches_registrant_change_request
+    pending_json = { new_registrant_id: @new_registrant.id }
+    @domain.update(pending_json: pending_json)
+    @domain.reload
+
+    assert @domain.registrant_update_confirmable?(@token)
+
+    get "/api/v1/registrant/confirms/#{@domain.name_puny}/change/#{@token}"
+    assert_equal(200, response.status)
+
+    res = JSON.parse(response.body, symbolize_names: true)
+    expected_body = {
+      domain_name: "hospital.test",
+      current_registrant: {
+        name: @registrant.name,
+        ident: @registrant.ident,
+        country: @registrant.ident_country_code
+      },
+      new_registrant: {
+        name: @new_registrant.name,
+        ident: @new_registrant.ident,
+        country: @new_registrant.ident_country_code
+      }
+    }
+
+    assert_equal expected_body, res
+  end
+
+  def test_approves_registrant_change_request
+    pending_json = { new_registrant_id: @new_registrant.id }
+    @domain.update(pending_json: pending_json)
+    @domain.reload
+
+    assert @domain.registrant_update_confirmable?(@token)
+
+    post "/api/v1/registrant/confirms/#{@domain.name_puny}/change/#{@token}/confirmed"
+    assert_equal(200, response.status)
+
+    res = JSON.parse(response.body, symbolize_names: true)
+    expected_body = {
+      domain_name: @domain.name,
+      current_registrant: {
+        name: @new_registrant.name,
+        ident: @new_registrant.ident,
+        country: @new_registrant.ident_country_code
+      },
+      status: 'confirmed'
+    }
+
+    assert_equal expected_body, res
+  end
+
+  def test_rejects_registrant_change_request
+    pending_json = { new_registrant_id: @new_registrant.id }
+    @domain.update(pending_json: pending_json)
+    @domain.reload
+
+    assert @domain.registrant_update_confirmable?(@token)
+
+    post "/api/v1/registrant/confirms/#{@domain.name_puny}/change/#{@token}/rejected"
+    assert_equal(200, response.status)
+
+    res = JSON.parse(response.body, symbolize_names: true)
+    expected_body = {
+      domain_name: @domain.name,
+      current_registrant: {
+        name: @registrant.name,
+        ident: @registrant.ident,
+        country: @registrant.ident_country_code
+      },
+      status: 'rejected'
+    }
+
+    assert_equal expected_body, res
+  end
+
+  def test_registrant_change_requires_valid_attributes
+    pending_json = { new_registrant_id: @new_registrant.id }
+    @domain.update(pending_json: pending_json)
+    @domain.reload
+
+    get "/api/v1/registrant/confirms/#{@domain.name_puny}/change/123"
+    assert_equal 401, response.status
+
+    get "/api/v1/registrant/confirms/aohldfjg.ee/change/123"
+    assert_equal 404, response.status
+
+    post "/api/v1/registrant/confirms/#{@domain.name_puny}/change/#{@token}/invalidaction"
+    assert_equal 404, response.status
+  end
+
+  def test_fetches_domain_delete_request
+    @domain.update(statuses: [DomainStatus::PENDING_DELETE_CONFIRMATION])
+    @domain.reload
+
+    assert @domain.registrant_delete_confirmable?(@token)
+
+    get "/api/v1/registrant/confirms/#{@domain.name_puny}/delete/#{@token}"
+    assert_equal(200, response.status)
+
+    res = JSON.parse(response.body, symbolize_names: true)
+    expected_body = {
+      domain_name: "hospital.test",
+      current_registrant: {
+        name: @registrant.name,
+        ident: @registrant.ident,
+        country: @registrant.ident_country_code
+      }
+    }
+
+    assert_equal expected_body, res
+  end
+
+  def test_approves_domain_delete_request
+    @domain.update(statuses: [DomainStatus::PENDING_DELETE_CONFIRMATION])
+    @domain.reload
+
+    assert @domain.registrant_delete_confirmable?(@token)
+
+    post "/api/v1/registrant/confirms/#{@domain.name_puny}/delete/#{@token}/confirmed"
+    assert_equal(200, response.status)
+
+    res = JSON.parse(response.body, symbolize_names: true)
+    expected_body = {
+      domain_name: @domain.name,
+      current_registrant: {
+        name: @registrant.name,
+        ident: @registrant.ident,
+        country: @registrant.ident_country_code
+      },
+      status: 'confirmed'
+    }
+
+    assert_equal expected_body, res
+  end
+
+  def test_rejects_domain_delete_request
+    @domain.update(statuses: [DomainStatus::PENDING_DELETE_CONFIRMATION])
+    @domain.reload
+
+    assert @domain.registrant_delete_confirmable?(@token)
+
+    post "/api/v1/registrant/confirms/#{@domain.name_puny}/delete/#{@token}/rejected"
+    assert_equal(200, response.status)
+
+    res = JSON.parse(response.body, symbolize_names: true)
+    expected_body = {
+      domain_name: @domain.name,
+      current_registrant: {
+        name: @registrant.name,
+        ident: @registrant.ident,
+        country: @registrant.ident_country_code
+      },
+      status: 'rejected'
+    }
+
+    assert_equal expected_body, res
+  end
+
+  def test_domain_delete_requires_valid_attributes
+    @domain.update(statuses: [DomainStatus::PENDING_DELETE_CONFIRMATION, DomainStatus::PENDING_DELETE])
+    @domain.reload
+
+    get "/api/v1/registrant/confirms/#{@domain.name_puny}/delete/123"
+    assert_equal 401, response.status
+
+    get "/api/v1/registrant/confirms/aohldfjg.ee/delete/123"
+    assert_equal 404, response.status
+
+    post "/api/v1/registrant/confirms/#{@domain.name_puny}/delete/#{@token}/invalidaction"
+    assert_equal 404, response.status
+  end
+  #def test_get_non_existent_domain_details_by_uuid
+  #  get '/api/v1/registrant/domains/random-uuid', headers: @auth_headers
+  #  assert_equal(404, response.status)
+
+  #  response_json = JSON.parse(response.body, symbolize_names: true)
+  #  assert_equal({ errors: [base: ['Domain not found']] }, response_json)
+  #end
+
+  #def test_root_returns_domain_list
+  #  get '/api/v1/registrant/domains', headers: @auth_headers
+  #  assert_equal(200, response.status)
+
+  #  response_json = JSON.parse(response.body, symbolize_names: true)
+  #  array_of_domain_names = response_json.map { |x| x[:name] }
+  #  assert(array_of_domain_names.include?('hospital.test'))
+
+  #  array_of_domain_registrars = response_json.map { |x| x[:registrar] }
+  #  assert(array_of_domain_registrars.include?({name: 'Good Names', website: nil}))
+  #end
+
+  #def test_root_accepts_limit_and_offset_parameters
+  #  get '/api/v1/registrant/domains', params: { 'limit' => 2, 'offset' => 0 },
+  #      headers: @auth_headers
+  #  response_json = JSON.parse(response.body, symbolize_names: true)
+
+  #  assert_equal(200, response.status)
+  #  assert_equal(2, response_json.count)
+
+  #  get '/api/v1/registrant/domains', headers: @auth_headers
+  #  response_json = JSON.parse(response.body, symbolize_names: true)
+
+  #  assert_equal(4, response_json.count)
+  #end
+
+  #def test_root_does_not_accept_limit_higher_than_200
+  #  get '/api/v1/registrant/domains', params: { 'limit' => 400, 'offset' => 0 },
+  #      headers: @auth_headers
+
+  #  assert_equal(400, response.status)
+  #  response_json = JSON.parse(response.body, symbolize_names: true)
+  #  assert_equal({ errors: [{ limit: ['parameter is out of range'] }] }, response_json)
+  #end
+
+  #def test_root_does_not_accept_offset_lower_than_0
+  #  get '/api/v1/registrant/domains', params: { 'limit' => 200, 'offset' => "-10" },
+  #      headers: @auth_headers
+
+  #  assert_equal(400, response.status)
+  #  response_json = JSON.parse(response.body, symbolize_names: true)
+  #  assert_equal({ errors: [{ offset: ['parameter is out of range'] }] }, response_json)
+  #end
+
+  #def test_root_returns_401_without_authorization
+  #  get '/api/v1/registrant/domains'
+  #  assert_equal(401, response.status)
+  #  json_body = JSON.parse(response.body, symbolize_names: true)
+
+  #  assert_equal({ errors: [base: ['Not authorized']] }, json_body)
+  #end
+
+  #def test_details_returns_401_without_authorization
+  #  get '/api/v1/registrant/domains/5edda1a5-3548-41ee-8b65-6d60daf85a37'
+  #  assert_equal(401, response.status)
+  #  json_body = JSON.parse(response.body, symbolize_names: true)
+
+  #  assert_equal({ errors: [base: ['Not authorized']] }, json_body)
+  #end
+end


### PR DESCRIPTION
Dependency of [registrant_center#19](https://github.com/internetee/registrant_center/pull/19)

In `config/application.yml`, add a new property `registrant_portal_verifications_base_url`.

Leave it as `''` to use legacy registrant portal for confirmation mails. Populate it with root address (https://registrant.internet.ee for example) of new registrant_center to use new registrant_portal for confirmation mails.

- Get data about registrant change / domain delete
`GET /api/v1/registrant/confirms/<domain>/change/<token>`
`GET /api/v1/registrant/confirms/<domain>/delete/<token>`

- Approve / Reject registrant change action
`POST /api/v1/registrant/confirms/<domain>/change/<token>/confirmed`
`POST /api/v1/registrant/confirms/<domain>/change/<token>/rejected`

- Approve / Reject domain delete action
`POST /api/v1/registrant/confirms/<domain>/delete/<token>/confirmed`
`POST /api/v1/registrant/confirms/<domain>/delete/<token>/rejected`