### PR TITLE
Fix automatic status handling / exposed contact attributes

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -574,7 +574,7 @@ class Domain < ApplicationRecord
 
     if statuses.empty? && valid?
       statuses << DomainStatus::OK
-    elsif (statuses.length > 1 && active?) || !valid?
+    elsif (statuses.length > 1) || !valid?
       statuses.delete(DomainStatus::OK)
     end
 

--- a/app/models/epp/domain.rb
+++ b/app/models/epp/domain.rb
@@ -27,7 +27,7 @@ class Epp::Domain < Domain
     active_techs = tech_domain_contacts.select { |x| !x.marked_for_destruction? }
 
     # validate registrant here as well
-    ([registrant] + active_admins + active_techs).each do |x|
+    ([Contact.find_by(code: registrant.code)] + active_admins + active_techs).each do |x|
       unless x.valid?
         add_epp_error('2304', nil, nil, I18n.t(:contact_is_not_valid, value: x.code))
         ok = false


### PR DESCRIPTION
Prevents `ok` / `inactive` statuses to coexist when domain's nameservers are removed.

Also, while managing domain contacts' disclosed attributes, it searches for the disclosable fields strictly from Contact's class. 