### PR TITLE
Registrant API: Exclude tech from default domain list query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+02.02.2021
+* Fixed updateProhibited status not affecting bulk tech contact change operation [#1820](https://github.com/internetee/registry/pull/1820)
+
 01.02.2021
 * Improved tests for admin interface [#1805](https://github.com/internetee/registry/pull/1805)
 

--- a/app/controllers/api/v1/registrant/auth_controller.rb
+++ b/app/controllers/api/v1/registrant/auth_controller.rb
@@ -19,8 +19,9 @@ module Api
           token = create_token(user)
 
           if token
-            ToStdout.msg("Bearer for #{eid_params[:first_name]} #{eid_params[:last_name]} " \
-                         "(#{eid_params[:ident]}) - '#{token[:access_token]}'")
+            msg = "Bearer for #{eid_params[:first_name]} #{eid_params[:last_name]} " \
+                  "(#{eid_params[:ident]}) - '#{token[:access_token]}'"
+            ToStdout.msg(msg) unless Rails.env.production?
             render json: token
           else
             render json: { errors: [{ base: ['Cannot create generate session token'] }] }

--- a/app/controllers/api/v1/registrant/domains_controller.rb
+++ b/app/controllers/api/v1/registrant/domains_controller.rb
@@ -25,7 +25,8 @@ module Api
             serializer.to_json
           end
 
-          render json: { count: domains.count, domains: serialized_domains }
+          render json: { total: current_user_domains_total_count, count: domains.count,
+                         domains: serialized_domains }
         end
 
         def show
@@ -40,6 +41,12 @@ module Api
         end
 
         private
+
+        def current_user_domains_total_count
+          current_registrant_user.domains.count
+        rescue CompanyRegister::NotAvailableError
+          current_registrant_user.direct_domains.count
+        end
 
         def current_user_domains
           current_registrant_user.domains(admin: params[:tech] != 'true')

--- a/app/controllers/api/v1/registrant/domains_controller.rb
+++ b/app/controllers/api/v1/registrant/domains_controller.rb
@@ -44,7 +44,7 @@ module Api
         def current_user_domains
           current_registrant_user.domains(admin: params[:tech] != 'true')
         rescue CompanyRegister::NotAvailableError
-          current_registrant_user.direct_domains
+          current_registrant_user.direct_domains(admin: params[:tech] != 'true')
         end
       end
     end

--- a/app/controllers/api/v1/registrant/domains_controller.rb
+++ b/app/controllers/api/v1/registrant/domains_controller.rb
@@ -42,7 +42,7 @@ module Api
         private
 
         def current_user_domains
-          current_registrant_user.domains
+          current_registrant_user.domains(admin: params[:tech] != 'true')
         rescue CompanyRegister::NotAvailableError
           current_registrant_user.direct_domains
         end

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -207,6 +207,14 @@ class Domain < ApplicationRecord
       )
     end
 
+    def registrant_user_direct_admin_registrant_domains(registrant_user)
+      from(
+        "(#{registrant_user_direct_domains_by_registrant(registrant_user).to_sql} UNION " \
+        "#{registrant_user_direct_domains_by_contact(registrant_user,
+                                                     except_tech: true).to_sql}) AS domains"
+      )
+    end
+
     def registrant_user_domains(registrant_user)
       from(
         "(#{registrant_user_domains_by_registrant(registrant_user).to_sql} UNION " \
@@ -256,8 +264,10 @@ class Domain < ApplicationRecord
       where(registrant: registrant_user.direct_contacts)
     end
 
-    def registrant_user_direct_domains_by_contact(registrant_user)
-      joins(:domain_contacts).where(domain_contacts: { contact_id: registrant_user.direct_contacts })
+    def registrant_user_direct_domains_by_contact(registrant_user, except_tech: false)
+      request = { contact_id: registrant_user.direct_contacts }
+      request[:type] = [AdminDomainContact.name] if except_tech
+      joins(:domain_contacts).where(domain_contacts: request)
     end
 
     def registrant_user_company_registrant(companies)

--- a/app/models/registrant_user.rb
+++ b/app/models/registrant_user.rb
@@ -36,7 +36,9 @@ class RegistrantUser < User
     Domain.registrant_user_domains(self)
   end
 
-  def direct_domains
+  def direct_domains(admin: false)
+    return Domain.registrant_user_direct_admin_registrant_domains(self) if admin
+
     Domain.registrant_user_direct_domains(self)
   end
 

--- a/app/models/registrant_user.rb
+++ b/app/models/registrant_user.rb
@@ -30,7 +30,9 @@ class RegistrantUser < User
     Contact.registrant_user_direct_contacts(self)
   end
 
-  def domains
+  def domains(admin: false)
+    return Domain.registrant_user_admin_registrant_domains(self) if admin
+
     Domain.registrant_user_domains(self)
   end
 

--- a/lib/serializers/registrant_api/domain.rb
+++ b/lib/serializers/registrant_api/domain.rb
@@ -25,6 +25,7 @@ module Serializers
           registrant: {
             name: domain.registrant.name,
             id: domain.registrant.uuid,
+            org: domain.registrant.org?,
           },
           tech_contacts: contacts(:tech),
           admin_contacts: contacts(:admin),
@@ -60,7 +61,7 @@ module Serializers
           registrar: { name: domain.registrar.name, website: domain.registrar.website },
           registrant: { name: domain.registrant.name, id: domain.registrant.uuid,
                         phone: domain.registrant.phone, email: domain.registrant.email,
-                        ident: domain.registrant.ident }
+                        ident: domain.registrant.ident, org: domain.registrant.org? }
         }
       end
 

--- a/test/integration/api/registrant/registrant_api_domains_test.rb
+++ b/test/integration/api/registrant/registrant_api_domains_test.rb
@@ -19,7 +19,7 @@ class RegistrantApiDomainsTest < ApplicationIntegrationTest
 
     assert_equal('hospital.test', domain[:name])
     assert_equal('5edda1a5-3548-41ee-8b65-6d60daf85a37', domain[:id])
-    assert_equal({name: 'John', id: 'eb2f2766-b44c-4e14-9f16-32ab1a7cb957'}, domain[:registrant])
+    assert_equal({name: 'John', id: 'eb2f2766-b44c-4e14-9f16-32ab1a7cb957', org: false}, domain[:registrant])
     assert_equal([{name: 'John',
                    id: 'eb2f2766-b44c-4e14-9f16-32ab1a7cb957',
                    email: 'john@inbox.test'}],

--- a/test/integration/api/registrant/registrant_api_domains_test.rb
+++ b/test/integration/api/registrant/registrant_api_domains_test.rb
@@ -89,6 +89,15 @@ class RegistrantApiDomainsTest < ApplicationIntegrationTest
     end
   end  
 
+  def test_domains_total_if_an_incomplete_list_is_returned
+    get '/api/v1/registrant/domains', headers: @auth_headers, params: { 'offset' => 0 }
+    assert_equal(200, response.status)
+
+    response_json = JSON.parse(response.body, symbolize_names: true)
+    assert_equal response_json[:domains].length, 4
+    assert_equal response_json[:total], 5
+  end
+
   def test_root_accepts_limit_and_offset_parameters
     get '/api/v1/registrant/domains', params: { 'limit' => 2, 'offset' => 0 },
         headers: @auth_headers

--- a/test/integration/api/registrant/registrant_api_domains_test.rb
+++ b/test/integration/api/registrant/registrant_api_domains_test.rb
@@ -5,9 +5,10 @@ class RegistrantApiDomainsTest < ApplicationIntegrationTest
   def setup
     super
 
-    @domain = domains(:hospital)
+    @domain = domains(:airport)
     @registrant = @domain.registrant
     @user = users(:registrant)
+    domains(:metro).tech_domain_contacts.update(contact_id: @registrant.id)
     @auth_headers = { 'HTTP_AUTHORIZATION' => auth_token }
   end
 
@@ -56,6 +57,37 @@ class RegistrantApiDomainsTest < ApplicationIntegrationTest
     array_of_domain_registrars = response_json[:domains].map { |x| x[:registrar] }
     assert(array_of_domain_registrars.include?({name: 'Good Names', website: nil}))
   end
+
+  def test_return_domain_list_with_registrants_and_admins
+    domains(:hospital).admin_domain_contacts.update(contact_id: contacts(:william).id)
+    domains(:hospital).update(registrant: contacts(:william).becomes(Registrant)) 
+
+    get '/api/v1/registrant/domains', headers: @auth_headers, params: { 'offset' => 0 }
+    assert_equal(200, response.status)
+
+    response_json = JSON.parse(response.body, symbolize_names: true)
+    response_json[:domains].each do |x| 
+      if x[:registrant][:org] == false
+        x[:tech_contacts].each do |s|
+          assert_not s[:name].include?(@registrant.name)
+        end
+      end
+    end
+  end
+
+  def test_return_domain_list_with_registrants_and_admins_tech
+    get '/api/v1/registrant/domains', headers: @auth_headers, params: { 'offset' => 0, 'tech' => true }
+    assert_equal(200, response.status)
+
+    response_json = JSON.parse(response.body, symbolize_names: true)
+    response_json[:domains].each do |x| 
+      if x[:name] == 'metro.test'
+        x[:tech_contacts].each do |s|
+            assert s[:name].include?(@registrant.name)
+        end
+      end
+    end
+  end  
 
   def test_root_accepts_limit_and_offset_parameters
     get '/api/v1/registrant/domains', params: { 'limit' => 2, 'offset' => 0 },

--- a/test/integration/api/registrant/registrant_api_domains_test.rb
+++ b/test/integration/api/registrant/registrant_api_domains_test.rb
@@ -94,7 +94,7 @@ class RegistrantApiDomainsTest < ApplicationIntegrationTest
     assert_equal(200, response.status)
 
     response_json = JSON.parse(response.body, symbolize_names: true)
-    assert_equal response_json[:domains].length, 4
+    assert_equal response_json[:domains].length, response_json[:count]
     assert_equal response_json[:total], 5
   end
 

--- a/test/integration/api/registrant/registrant_api_registry_locks_test.rb
+++ b/test/integration/api/registrant/registrant_api_registry_locks_test.rb
@@ -130,7 +130,7 @@ class RegistrantApiRegistryLocksTest < ApplicationIntegrationTest
     response_json = JSON.parse(response.body, symbolize_names: true)
 
     assert_equal({ name: 'Best Names', website: 'https://bestnames.test' }, response_json[:registrar])
-    assert_equal({name: 'John', id: 'eb2f2766-b44c-4e14-9f16-32ab1a7cb957'}, response_json[:registrant])
+    assert_equal({name: 'John', id: 'eb2f2766-b44c-4e14-9f16-32ab1a7cb957', org: false}, response_json[:registrant])
     assert_equal([{name: 'Jane',
                    id: '9db3de62-2414-4487-bee2-d5c155567768',
                    email: 'jane@mail.test'

--- a/test/lib/serializers/registrant_api/domain_test.rb
+++ b/test/lib/serializers/registrant_api/domain_test.rb
@@ -30,8 +30,8 @@ class SerializersRegistrantApiDomainTest < ActiveSupport::TestCase
     assert_equal({name: 'Best Names', website: 'https://bestnames.test' }, @json[:registrar])
   end
 
-  def test_returns_registrant_name_and_uuid
-    assert_equal({name: 'John', id: 'eb2f2766-b44c-4e14-9f16-32ab1a7cb957'},
+  def test_returns_registrant_name_uuid_and_org
+    assert_equal({name: 'John', id: 'eb2f2766-b44c-4e14-9f16-32ab1a7cb957', org: false},
                  @json[:registrant])
   end
 


### PR DESCRIPTION
Related to [registrant_center#38](https://github.com/internetee/registrant_center/issues/38)
Related to [registrant_center#29](https://github.com/internetee/registrant_center/issues/29)

For example:

`/api/v1/registrant/domains` - Returns domain with registrant / admin links
`/api/v1/registrant/domains?tech=true` - Returns domains with registrant / admin / tech links

Also introduced `org` boolean to domain's registrant object to determine whether the domain belongs to organization or not.