### PR TITLE
BouncedMailAddress: Remove from AWS suppression list upon destroy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,3 +92,5 @@ group :test do
   gem 'webdrivers'
   gem 'webmock'
 end
+
+gem "aws-sdk-ses", "~> 1.37"

--- a/Gemfile
+++ b/Gemfile
@@ -93,4 +93,4 @@ group :test do
   gem 'webmock'
 end
 
-gem "aws-sdk-sesv2", "~> 1.16"
+gem 'aws-sdk-sesv2', '~> 1.16'

--- a/Gemfile
+++ b/Gemfile
@@ -93,4 +93,4 @@ group :test do
   gem 'webmock'
 end
 
-gem "aws-sdk-ses", "~> 1.37"
+gem "aws-sdk-sesv2", "~> 1.16"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,18 @@ GEM
     attr_required (1.0.1)
     autoprefixer-rails (10.0.0.2)
       execjs
+    aws-eventstream (1.1.0)
+    aws-partitions (1.424.0)
+    aws-sdk-core (3.112.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-ses (1.37.0)
+      aws-sdk-core (~> 3, >= 3.112.0)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.2.2)
+      aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.16)
     bindata (2.4.8)
     bootsnap (1.4.8)
@@ -226,6 +238,7 @@ GEM
     i18n_data (0.10.0)
     isikukood (0.1.2)
     iso8601 (0.12.1)
+    jmespath (1.4.0)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -484,6 +497,7 @@ DEPENDENCIES
   active_interaction (~> 3.8)
   activerecord-import
   airbrake
+  aws-sdk-ses (~> 1.37)
   bootsnap (>= 1.1.0)
   bootstrap-sass (~> 3.4)
   cancancan

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-ses (1.37.0)
+    aws-sdk-sesv2 (1.16.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.2)
@@ -497,7 +497,7 @@ DEPENDENCIES
   active_interaction (~> 3.8)
   activerecord-import
   airbrake
-  aws-sdk-ses (~> 1.37)
+  aws-sdk-sesv2 (~> 1.16)
   bootsnap (>= 1.1.0)
   bootstrap-sass (~> 3.4)
   cancancan

--- a/app/models/bounced_mail_address.rb
+++ b/app/models/bounced_mail_address.rb
@@ -1,5 +1,6 @@
 class BouncedMailAddress < ApplicationRecord
   validates :email, :message_id, :bounce_type, :bounce_subtype, :action, :status, presence: true
+  after_destroy :destroy_aws_suppression
 
   def bounce_reason
     "#{action} (#{status} #{diagnostic})"
@@ -24,5 +25,21 @@ class BouncedMailAddress < ApplicationRecord
       status: bounced_record['status'],
       diagnostic: bounced_record['diagnosticCode'],
     }
+  end
+
+  def destroy_aws_suppression
+    return unless BouncedMailAddress.ses_configured?
+
+    res = Aws::SESV2::Client.new.delete_suppressed_destination({ email_address: email })
+    res.successful?
+  rescue Aws::SESV2::Errors::ServiceError => e
+    logger.warn("Suppression not removed. #{e}")
+  end
+
+  def self.ses_configured?
+    ses ||= Aws::SES::Client.new
+    ses.config.credentials.access_key_id.present?
+  rescue Aws::Errors::MissingRegionError
+    false
   end
 end

--- a/app/models/bounced_mail_address.rb
+++ b/app/models/bounced_mail_address.rb
@@ -30,14 +30,14 @@ class BouncedMailAddress < ApplicationRecord
   def destroy_aws_suppression
     return unless BouncedMailAddress.ses_configured?
 
-    res = Aws::SESV2::Client.new.delete_suppressed_destination({ email_address: email })
+    res = Aws::SESV2::Client.new.delete_suppressed_destination(email_address: email)
     res.successful?
   rescue Aws::SESV2::Errors::ServiceError => e
     logger.warn("Suppression not removed. #{e}")
   end
 
   def self.ses_configured?
-    ses ||= Aws::SES::Client.new
+    ses ||= Aws::SESV2::Client.new
     ses.config.credentials.access_key_id.present?
   rescue Aws::Errors::MissingRegionError
     false

--- a/config/initializers/aws_ses.rb
+++ b/config/initializers/aws_ses.rb
@@ -1,0 +1,4 @@
+Aws.config.update(
+  region: ENV['aws_default_region'],
+  credentials: Aws::Credentials.new(ENV['aws_access_key_id'], ENV['aws_secret_access_key'])
+)


### PR DESCRIPTION
Closes #1839 

Requires following keys in `config/application.yml`

```
# Variables for Amazon SES
aws_access_key_id: <Amazon's access key id>
aws_secret_access_key: <Amazon's secret access key>
aws_default_region: <Amazon account's region code>
```