### PR TITLE
RWHOIS Bridge: Create separate key for Bounces API

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -11,7 +11,7 @@ module Api
       end
 
       def authenticate_shared_key
-        api_key = "Basic #{ENV['internal_api_key']}"
+        api_key = "Basic #{ENV['rwhois_internal_api_shared_key']}"
         head(:unauthorized) unless api_key == request.authorization
       end
 

--- a/app/controllers/api/v1/bounces_controller.rb
+++ b/app/controllers/api/v1/bounces_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class BouncesController < BaseController
-      before_action :authenticate_shared_key
+      before_action :validate_shared_key_integrity
 
       # POST api/v1/bounces/
       def create
@@ -19,6 +19,13 @@ module Api
         end
 
         params.require(:data)
+      end
+
+      private
+
+      def validate_shared_key_integrity
+        api_key = "Basic #{ENV['rwhois_bounces_api_shared_key']}"
+        head(:unauthorized) unless api_key == request.authorization
       end
     end
   end

--- a/config/application.yml.sample
+++ b/config/application.yml.sample
@@ -87,11 +87,11 @@ sk_digi_doc_service_name: 'Testimine'
 registrant_api_base_url:
 registrant_api_auth_allowed_ips: '127.0.0.1, 0.0.0.0' #ips, separated with commas
 
-# Bounces API
-api_shared_key: testkey
+# Shared key for REST-WHOIS Bounces API incl. CERT
+rwhois_bounces_api_shared_key: testkey
 
 # Link to REST-WHOIS API
-internal_api_key: testkey
+rwhois_internal_api_shared_key: testkey
 
 # Base URL (inc. https://) of REST registrant portal
 # Leave blank to use internal registrant portal

--- a/test/integration/api/v1/bounces/create_test.rb
+++ b/test/integration/api/v1/bounces/create_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class BouncesApiV1CreateTest < ActionDispatch::IntegrationTest
   def setup
-    @api_key = "Basic #{ENV['api_shared_key']}"
+    @api_key = "Basic #{ENV['rwhois_bounces_api_shared_key']}"
     @headers = { "Authorization": "#{@api_key}" }
     @json_body = { "data": valid_bounce_request }.as_json
   end

--- a/test/integration/api/v1/contact_requests_test.rb
+++ b/test/integration/api/v1/contact_requests_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class ApiV1ContactRequestTest < ActionDispatch::IntegrationTest
   def setup
-    @api_key = "Basic #{ENV['api_shared_key']}"
+    @api_key = "Basic #{ENV['rwhois_internal_api_shared_key']}"
     @headers = { "Authorization": "#{@api_key}" }
     @json_create = { "contact_request": valid_contact_request_create }.as_json
     @json_update = { "contact_request": valid_contact_request_update }.as_json


### PR DESCRIPTION
RWHOIS Contact requests API key is now named as `rwhois_internal_api_shared_key`
This key must match rest-whois side `registry_api_key ` key.

`registry` `rwhois_internal_api_shared_key` == `rwhois` `registry_api_key`


RWHOIS Bounce API key is now named as `rwhois_bounces_api_shared_key`
This key must match rest-whois side `bounces_api_shared_key` key.

`registry` `rwhois_bounces_api_shared_key` == `rwhois` `bounces_api_shared_key`