### PR TITLE
Update mimemagic version since older versions was dropped by maintainer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 gem 'active_interaction', '~> 3.8'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'iso8601', '0.12.1' # for dates and times
+gem 'mimemagic', '~> 0.3.7'
 gem 'rails', '~> 6.0'
 gem 'rest-client'
 gem 'uglifier'

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gem 'active_interaction', '~> 3.8'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'iso8601', '0.12.1' # for dates and times
-gem 'mimemagic', '~> 0.3.7'
+gem 'mimemagic', '~> 0.3.10'
 gem 'rails', '~> 6.0'
 gem 'rest-client'
 gem 'uglifier'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -529,7 +529,7 @@ DEPENDENCIES
   jquery-ui-rails (= 5.0.5)
   kaminari
   lhv!
-  mimemagic (~> 0.3.7)
+  mimemagic (~> 0.3.10)
   minitest (~> 5.14)
   money-rails
   nokogiri (~> 1.10.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,7 +281,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.4)
@@ -527,6 +529,7 @@ DEPENDENCIES
   jquery-ui-rails (= 5.0.5)
   kaminari
   lhv!
+  mimemagic (~> 0.3.7)
   minitest (~> 5.14)
   money-rails
   nokogiri (~> 1.10.0)


### PR DESCRIPTION
Mimemagic gem of versions less than 0.3.7 doesn't exist anymore due to licensing issues, maintainer issued version 0.3.7.
We should update gems ASAP for registry images to be built.