### PR TITLE
1915 failed attempt from delayed jobs

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -2,26 +2,10 @@ class ApplicationMailer < ActionMailer::Base
   append_view_path Rails.root.join('app', 'views', 'mailers')
   layout 'mailer'
 
-  before_action :verification_before_send
-
   def registrant_confirm_url(domain:, method:)
     token = domain.registrant_verification_token
     base_url = ENV['registrant_portal_verifications_base_url']
 
     "#{base_url}/confirmation/#{domain.name_puny}/#{method}/#{token}"
-  end
-
-  def verification_before_send
-    p '==================================================================='
-    p '==================================================================='
-    p '==================================================================='
-    p '==================================================================='
-    p '==================================================================='
-    p mail
-    p '==================================================================='
-    p '==================================================================='
-    p '==================================================================='
-    p '==================================================================='
-    p '==================================================================='
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -2,10 +2,26 @@ class ApplicationMailer < ActionMailer::Base
   append_view_path Rails.root.join('app', 'views', 'mailers')
   layout 'mailer'
 
+  before_action :verification_before_send
+
   def registrant_confirm_url(domain:, method:)
     token = domain.registrant_verification_token
     base_url = ENV['registrant_portal_verifications_base_url']
 
     "#{base_url}/confirmation/#{domain.name_puny}/#{method}/#{token}"
+  end
+
+  def verification_before_send
+    p '==================================================================='
+    p '==================================================================='
+    p '==================================================================='
+    p '==================================================================='
+    p '==================================================================='
+    p mail
+    p '==================================================================='
+    p '==================================================================='
+    p '==================================================================='
+    p '==================================================================='
+    p '==================================================================='
   end
 end

--- a/lib/tasks/collect_invalid_validation_contacts.rake
+++ b/lib/tasks/collect_invalid_validation_contacts.rake
@@ -1,0 +1,38 @@
+namespace :collect_invalid_contacts do
+  desc 'Starts collect invalid validation contacts'
+  task all_domains: :environment do
+    Contact.all.each do |contact|
+      result = Truemail.validate(contact.email, with: :mx)
+      unless result.result.success
+        collect_data_for_csv(contact, result.result)
+      end
+    end
+  end
+end
+
+def find_related_domains(contact)
+  Domain.where(id: contact.id)
+end
+
+def collect_data_for_csv(contact, result)
+  domains = find_related_domains(contact)
+
+  headers = %w[
+    contact
+    domain
+    error
+  ]
+
+  CSV.open('invalid_email.csv', 'w') do |csv|
+    csv << headers
+
+    domains.each do |domain|
+      attrs = []
+      attrs.push(domain)
+      attrs.push(contact.email)
+      attrs.push(result.errors)
+
+      csv << attrs
+    end
+  end
+end

--- a/lib/tasks/collect_invalid_validation_contacts.rake
+++ b/lib/tasks/collect_invalid_validation_contacts.rake
@@ -1,9 +1,11 @@
 namespace :collect_invalid_contacts do
   desc 'Starts collect invalid validation contacts'
   task all_domains: :environment do
+    prepare_csv_file
+
     Contact.all.each do |contact|
       result = Truemail.validate(contact.email, with: :mx)
-      unless result.result.success
+      if !result.result.success && !validate_puny_code(contact.email)
         collect_data_for_csv(contact, result.result)
       end
     end
@@ -11,28 +13,61 @@ namespace :collect_invalid_contacts do
 end
 
 def find_related_domains(contact)
-  Domain.where(id: contact.id)
+  registrant_domains = Domain.where(registrant_id: contact.id)
+
+  tech_domains = collect_tech_domains(contact)
+  admin_domains = collect_admin_domains(contact)
+
+  tech_domains | admin_domains | registrant_domains
+end
+
+def collect_admin_domains(contact)
+  admin_domains = []
+
+  admin_contacts = AdminDomainContact.where(contact_id: contact.id)
+  admin_contacts.each do |c|
+    admin_domains << Domain.find(c.domain_id)
+  end
+
+  admin_domains
+end
+
+def collect_tech_domains(contact)
+  tech_domains = []
+
+  tech_contacts = TechDomainContact.where(contact_id: contact.id)
+  tech_contacts.each do |c|
+    tech_domains << Domain.find(c.domain_id)
+  end
+
+  tech_domains
 end
 
 def collect_data_for_csv(contact, result)
   domains = find_related_domains(contact)
 
-  headers = %w[
-    contact
-    domain
-    error
-  ]
-
-  CSV.open('invalid_email.csv', 'w') do |csv|
-    csv << headers
-
+  CSV.open('invalid_emails.csv', 'a') do |csv|
     domains.each do |domain|
       attrs = []
-      attrs.push(domain)
+      attrs.push(domain.name)
       attrs.push(contact.email)
       attrs.push(result.errors)
 
       csv << attrs
     end
   end
+end
+
+def prepare_csv_file
+  headers = %w[
+    contact
+    domain
+    error
+  ]
+  csv = CSV.open('invalid_emails.csv', 'w')
+  csv << headers
+end
+
+def validate_puny_code(email)
+  email.include?('xn--')
 end


### PR DESCRIPTION
This PR adds a task to validate contact email addresses with truemail gem on level MX and generates a list of domains associated with failed email addresses that have not been invalidated and set to force delete already. The goal is to get the snapshot of the quality of email addresses in the registry prior to running the periodic scanner that would set related domains to be forcedeleted on detection.