### PR TITLE
REPP: bulk nameservers addition

### DIFF
--- a/app/controllers/registrar/nameservers_controller.rb
+++ b/app/controllers/registrar/nameservers_controller.rb
@@ -32,7 +32,8 @@ class Registrar
     end
 
     def compose_notice_message(res)
-      notices = ["#{t('.replaced')}. #{t('.affected_domains')}: " \
+      action_text = params[:old_hostname].blank? ? t('.added') : t('.replaced')
+      notices = ["#{action_text}. #{t('.affected_domains')}: " \
       "#{res[:data][:affected_domains].join(', ')}"]
 
       notices << "#{t('.skipped_domains')}: #{res[:data][:skipped_domains].join(', ')}" if res[:data][:skipped_domains]
@@ -42,7 +43,7 @@ class Registrar
 
     def csv_list_empty_guard
       notice = 'CSV scoped domain list seems empty. Make sure that domains are added and ' \
-      '"domain_name" header is present.'
+      '"Domain" header is present.'
       redirect_to(registrar_domains_url, flash: { notice: notice })
     end
 
@@ -52,9 +53,9 @@ class Registrar
       domains = []
       csv = CSV.read(params[:puny_file].path, headers: true)
 
-      return [] if csv['domain_name'].blank?
+      return [] if csv['Domain'].blank?
 
-      csv.map { |b| domains << b['domain_name'] }
+      csv.map { |b| domains << b['Domain'] }
 
       domains.compact
     rescue CSV::MalformedCSVError

--- a/app/controllers/repp/v1/registrar/nameservers_controller.rb
+++ b/app/controllers/repp/v1/registrar/nameservers_controller.rb
@@ -67,7 +67,7 @@ module Repp
         end
 
         def verify_nameserver_existance
-          return true if hostname.nil?
+          return true if hostname.blank?
 
           current_user.registrar.nameservers.find_by!(hostname: hostname)
         end

--- a/app/controllers/repp/v1/registrar/nameservers_controller.rb
+++ b/app/controllers/repp/v1/registrar/nameservers_controller.rb
@@ -18,7 +18,7 @@ module Repp
           end
         end
 
-        def update
+        def update  # rubocop:disable Metrics/MethodLength
           affected, errored = if hostname.present?
                                 current_user.registrar.replace_nameservers(hostname,
                                                                            hostname_params[:data][:attributes],

--- a/app/controllers/repp/v1/registrar/nameservers_controller.rb
+++ b/app/controllers/repp/v1/registrar/nameservers_controller.rb
@@ -8,7 +8,7 @@ module Repp
         desc 'bulk nameserver change'
         param :data, Hash, required: true, desc: 'Object holding nameserver changes' do
           param :type, String, required: true, desc: 'Always set as "nameserver"'
-          param :id, String, required: true, desc: 'Hostname of replacable nameserver'
+          param :id, String, required: false, desc: 'Hostname of replacable nameserver'
           param :domains, Array, required: false, desc: 'Array of domain names qualified for ' \
                                                        'nameserver replacement'
           param :attributes, Hash, required: true, desc: 'Object holding new nameserver values' do
@@ -17,11 +17,16 @@ module Repp
             param :ipv6, Array, of: String, required: false, desc: 'Array of fixed IPv6 addresses'
           end
         end
+
         def update
-          affected, errored = current_user.registrar
-                                          .replace_nameservers(hostname,
-                                                               hostname_params[:data][:attributes],
-                                                               domains: domains_from_params)
+          affected, errored = if hostname.present?
+                                current_user.registrar.replace_nameservers(hostname,
+                                                                           hostname_params[:data][:attributes],
+                                                                           domains: domains_from_params)
+                              else
+                                current_user.registrar.add_nameservers(hostname_params[:data][:attributes],
+                                                                       domains: domains_from_params)
+                              end
 
           render_success(data: data_format_for_success(affected, errored))
         rescue ActiveRecord::RecordInvalid => e
@@ -47,7 +52,7 @@ module Repp
         end
 
         def hostname_params
-          params.require(:data).require(%i[type id])
+          params.require(:data).require(%i[type])
           params.require(:data).require(:attributes).require([:hostname])
 
           params.permit(data: [
@@ -58,10 +63,12 @@ module Repp
         end
 
         def hostname
-          hostname_params[:data][:id]
+          hostname_params[:data][:id] || nil
         end
 
         def verify_nameserver_existance
+          return true if hostname.nil?
+
           current_user.registrar.nameservers.find_by!(hostname: hostname)
         end
       end

--- a/app/models/concerns/domain/bulk_updatable.rb
+++ b/app/models/concerns/domain/bulk_updatable.rb
@@ -2,7 +2,7 @@ module Domain::BulkUpdatable
   extend ActiveSupport::Concern
 
   def bulk_update_prohibited?
-    discarded? || statuses_blocks_update?
+    statuses_blocks_update?
   end
 
   def statuses_blocks_update?

--- a/app/models/registrar.rb
+++ b/app/models/registrar.rb
@@ -187,7 +187,7 @@ class Registrar < ApplicationRecord
       domain_scope.each do |domain_name|
         domain = self.domains.find_by('name = ? OR name_puny = ?', domain_name, domain_name)
 
-        if !domain.present? || domain_not_updatable?(hostname: new_attributes[:hostname], domain: domain)
+        if domain.blank? || domain_not_updatable?(hostname: new_attributes[:hostname], domain: domain)
           failed_list << domain_name
           next
         end

--- a/app/views/registrar/bulk_change/_nameserver_form.html.erb
+++ b/app/views/registrar/bulk_change/_nameserver_form.html.erb
@@ -3,11 +3,11 @@
 
     <div class="form-group">
         <div class="col-md-2 control-label">
-            <%= label_tag :old_hostname %>
+            <%= label_tag t '.old_hostname' %>
         </div>
 
         <div class="col-md-4">
-            <%= text_field_tag :old_hostname, params[:old_hostname], required: true,
+            <%= text_field_tag :old_hostname, params[:old_hostname], required: false,
                                class: 'form-control' %>
         </div>
     </div>

--- a/app/views/registrar/bulk_change/_nameserver_form.html.erb
+++ b/app/views/registrar/bulk_change/_nameserver_form.html.erb
@@ -3,7 +3,7 @@
 
     <div class="form-group">
         <div class="col-md-2 control-label">
-            <%= label_tag t '.old_hostname' %>
+            <%= label_tag :old_hostname, t('.old_hostname') %>
         </div>
 
         <div class="col-md-4">

--- a/config/locales/registrar/bulk_change.en.yml
+++ b/config/locales/registrar/bulk_change.en.yml
@@ -32,6 +32,7 @@ en:
           ident data ie for updating contact information.
 
       nameserver_form:
+        old_hostname: Old hostname (optional)
         ip_hint: One IP per line
         replace_btn: Replace nameserver
         help_btn: Toggle help

--- a/config/locales/registrar/bulk_change.en.yml
+++ b/config/locales/registrar/bulk_change.en.yml
@@ -34,7 +34,7 @@ en:
       nameserver_form:
         old_hostname: Old hostname (optional)
         ip_hint: One IP per line
-        replace_btn: Replace nameserver
+        replace_btn: Replace/Add nameserver
         help_btn: Toggle help
         help: >-
           Replace nameserver specified in the "old hostname" with the one in "new hostname" with

--- a/config/locales/registrar/nameservers.en.yml
+++ b/config/locales/registrar/nameservers.en.yml
@@ -3,5 +3,6 @@ en:
     nameservers:
       update:
         replaced: Nameserver have been successfully replaced
+        added: Nameserver have been successfully added
         affected_domains: Affected domains
         skipped_domains: Untouched domains

--- a/test/fixtures/files/valid_domains_for_ns_replacement.csv
+++ b/test/fixtures/files/valid_domains_for_ns_replacement.csv
@@ -1,2 +1,2 @@
-domain_name
+Domain
 shop.test

--- a/test/integration/api/domain_admin_contacts_test.rb
+++ b/test/integration/api/domain_admin_contacts_test.rb
@@ -61,8 +61,8 @@ class APIDomainAdminContactsTest < ApplicationIntegrationTest
   end
 
   def test_return_skipped_domains_in_alphabetical_order
-    domains(:shop).update!(statuses: [DomainStatus::DELETE_CANDIDATE])
-    domains(:airport).update!(statuses: [DomainStatus::DELETE_CANDIDATE])
+    domains(:shop).update!(statuses: [DomainStatus::SERVER_UPDATE_PROHIBITED])
+    domains(:airport).update!(statuses: [DomainStatus::SERVER_UPDATE_PROHIBITED])
 
     patch '/repp/v1/domains/admin_contacts', params: { current_contact_id: @admin_current.code,
                                                  new_contact_id: @admin_new.code },

--- a/test/integration/api/domain_admin_contacts_test.rb
+++ b/test/integration/api/domain_admin_contacts_test.rb
@@ -38,7 +38,7 @@ class APIDomainAdminContactsTest < ApplicationIntegrationTest
   end
 
   def test_skip_discarded_domains
-    domains(:airport).update!(statuses: [DomainStatus::DELETE_CANDIDATE])
+    domains(:airport).update!(statuses: [DomainStatus::SERVER_UPDATE_PROHIBITED])
 
     patch '/repp/v1/domains/admin_contacts', params: { current_contact_id: @admin_current.code,
                                                  new_contact_id: @admin_new.code },

--- a/test/integration/api/domain_contacts_test.rb
+++ b/test/integration/api/domain_contacts_test.rb
@@ -12,7 +12,7 @@ class APIDomainContactsTest < ApplicationIntegrationTest
   end
 
   def test_skip_discarded_domains
-    domains(:airport).update!(statuses: [DomainStatus::DELETE_CANDIDATE])
+    domains(:airport).update!(statuses: [DomainStatus::SERVER_UPDATE_PROHIBITED])
 
     patch '/repp/v1/domains/contacts', params: { current_contact_id: 'william-001',
                                                  new_contact_id: 'john-001' },
@@ -33,8 +33,8 @@ class APIDomainContactsTest < ApplicationIntegrationTest
   end
 
   def test_return_skipped_domains_in_alphabetical_order
-    domains(:shop).update!(statuses: [DomainStatus::DELETE_CANDIDATE])
-    domains(:airport).update!(statuses: [DomainStatus::DELETE_CANDIDATE])
+    domains(:shop).update!(statuses: [DomainStatus::SERVER_UPDATE_PROHIBITED])
+    domains(:airport).update!(statuses: [DomainStatus::SERVER_UPDATE_PROHIBITED])
 
     patch '/repp/v1/domains/contacts', params: { current_contact_id: 'william-001',
                                                  new_contact_id: 'john-001' },

--- a/test/integration/repp/v1/registrar/nameservers_test.rb
+++ b/test/integration/repp/v1/registrar/nameservers_test.rb
@@ -57,6 +57,34 @@ class ReppV1RegistrarNameserversTest < ActionDispatch::IntegrationTest
     assert json[:data][:affected_domains].include? 'shop.test'
   end
 
+  def test_add_nameserver_values_to_array_of_domains
+    nameserver = nameservers(:shop_ns1)
+    airport_domain = domains(:airport)
+    airport_domain.update(statuses: [DomainStatus::FORCE_DELETE,
+                                     DomainStatus::SERVER_RENEW_PROHIBITED,
+                                     DomainStatus::SERVER_TRANSFER_PROHIBITED])
+    payload = {
+      "data": {
+        "type": 'nameserver',
+        "domains": ['shop.test', 'airport.test'],
+        "attributes": {
+          "hostname": "#{nameserver.hostname}.arraytest",
+          "ipv4": ['2.2.2.2']
+        }
+      }
+    }
+
+    put '/repp/v1/registrar/nameservers', headers: @auth_headers, params: payload
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    assert_response :ok
+    assert_equal 1000, json[:code]
+    assert_equal 'Command completed successfully', json[:message]
+    assert_equal({ hostname: "#{nameserver.hostname}.arraytest", ipv4: ['2.2.2.2'] }, json[:data][:attributes])
+    assert json[:data][:affected_domains].include? 'shop.test'
+    assert json[:data][:affected_domains].include? 'airport.test'
+  end
+
   def test_fails_to_update_if_prohibited
     domain = domains(:shop)
     domain.update(statuses: [DomainStatus::CLIENT_UPDATE_PROHIBITED])

--- a/test/integration/repp/v1/registrar/nameservers_test.rb
+++ b/test/integration/repp/v1/registrar/nameservers_test.rb
@@ -34,6 +34,29 @@ class ReppV1RegistrarNameserversTest < ActionDispatch::IntegrationTest
     assert json[:data][:affected_domains].include? 'shop.test'
   end
 
+  def test_add_nameserver_values
+    nameserver = nameservers(:shop_ns1)
+    payload = {
+      "data": {
+        "type": 'nameserver',
+        "domains": ['shop.test'],
+        "attributes": {
+          "hostname": "#{nameserver.hostname}.testtest",
+          "ipv4": ['2.2.2.2']
+        }
+      }
+    }
+
+    put '/repp/v1/registrar/nameservers', headers: @auth_headers, params: payload
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    assert_response :ok
+    assert_equal 1000, json[:code]
+    assert_equal 'Command completed successfully', json[:message]
+    assert_equal({ hostname: "#{nameserver.hostname}.testtest", ipv4: ['2.2.2.2'] }, json[:data][:attributes])
+    assert json[:data][:affected_domains].include? 'shop.test'
+  end
+
   def test_fails_to_update_if_prohibited
     domain = domains(:shop)
     domain.update(statuses: [DomainStatus::CLIENT_UPDATE_PROHIBITED])

--- a/test/system/registrar_area/bulk_change/nameserver_test.rb
+++ b/test/system/registrar_area/bulk_change/nameserver_test.rb
@@ -116,7 +116,7 @@ class RegistrarAreaNameserverBulkChangeTest < ApplicationSystemTestCase
     assert_text 'CSV scoped domain list seems empty. Make sure that domains are added and "Domain" header is present.'
   end
 
-  def test_replaces_current_registrar_nameservers
+  def test_adding_current_registrar_nameservers
     request_body = { data: { type: 'nameserver',
                              id: '',
                              domains: [],

--- a/test/system/registrar_area/bulk_change/nameserver_test.rb
+++ b/test/system/registrar_area/bulk_change/nameserver_test.rb
@@ -31,7 +31,7 @@ class RegistrarAreaNameserverBulkChangeTest < ApplicationSystemTestCase
     fill_in 'New hostname', with: 'new-ns.bestnames.test'
     fill_in 'ipv4', with: "192.0.2.55\n192.0.2.56"
     fill_in 'ipv6', with: "2001:db8::55\n2001:db8::56"
-    click_on 'Replace nameserver'
+    click_on 'Replace/Add nameserver'
 
     assert_requested request_stub
     assert_current_path registrar_domains_path
@@ -52,7 +52,7 @@ class RegistrarAreaNameserverBulkChangeTest < ApplicationSystemTestCase
     fill_in 'New hostname', with: 'new hostname'
     fill_in 'ipv4', with: 'ipv4'
     fill_in 'ipv6', with: 'ipv6'
-    click_on 'Replace nameserver'
+    click_on 'Replace/Add nameserver'
 
     assert_text 'epic fail'
     assert_field 'Old hostname', with: 'old hostname'
@@ -63,7 +63,7 @@ class RegistrarAreaNameserverBulkChangeTest < ApplicationSystemTestCase
 
   def test_replaces_nameservers_only_for_scoped_domains
     request_body = { data: { type: 'nameserver',
-                              id: 'ns1.bestnames.test',
+                             id: 'ns1.bestnames.test',
                              domains: ['shop.test'],
                              attributes: { hostname: 'new-ns.bestnames.test',
                                            ipv4: %w[192.0.2.55 192.0.2.56],
@@ -87,7 +87,7 @@ class RegistrarAreaNameserverBulkChangeTest < ApplicationSystemTestCase
     fill_in 'ipv6', with: "2001:db8::55\n2001:db8::56"
     attach_file :puny_file, Rails.root.join('test', 'fixtures', 'files', 'valid_domains_for_ns_replacement.csv').to_s
 
-    click_on 'Replace nameserver'
+    click_on 'Replace/Add nameserver'
 
     assert_requested request_stub
     assert_current_path registrar_domains_path
@@ -109,10 +109,76 @@ class RegistrarAreaNameserverBulkChangeTest < ApplicationSystemTestCase
     attach_file :puny_file, Rails.root.join('test', 'fixtures', 'files', 'invalid_domains_for_ns_replacement.csv').to_s
 
     assert_no_changes -> { nameserver.hostname } do
-      click_on 'Replace nameserver'
+      click_on 'Replace/Add nameserver'
     end
 
-    assert_current_path registrar_domains_path    
-    assert_text 'CSV scoped domain list seems empty. Make sure that domains are added and "domain_name" header is present.'
+    assert_current_path registrar_domains_path
+    assert_text 'CSV scoped domain list seems empty. Make sure that domains are added and "Domain" header is present.'
+  end
+
+  def test_replaces_current_registrar_nameservers
+    request_body = { data: { type: 'nameserver',
+                             id: '',
+                             domains: [],
+                             attributes: { hostname: 'new-ns2.bestnames.test',
+                                           ipv4: %w[192.0.2.55 192.0.2.56],
+                                           ipv6: %w[2001:db8::55 2001:db8::56] } } }
+    request_stub = stub_request(:put, /registrar\/nameservers/).with(body: request_body,
+                                                                     headers: { 'Content-type' => Mime[:json] },
+                                                                     basic_auth: ['test_goodnames', 'testtest'])
+                                                               .to_return(body: { data: {
+                                                                 type: 'nameserver',
+                                                                 id: 'new-ns2.bestnames.test',
+                                                                 affected_domains: ["airport.test", "shop.test"],
+                                                                 skipped_domains: []
+                                                               }
+                                                               }.to_json, status: 200)
+
+    visit registrar_domains_url
+    click_link 'Bulk change'
+    click_link 'Nameserver'
+
+    fill_in 'New hostname', with: 'new-ns2.bestnames.test'
+    fill_in 'ipv4', with: "192.0.2.55\n192.0.2.56"
+    fill_in 'ipv6', with: "2001:db8::55\n2001:db8::56"
+    click_on 'Replace/Add nameserver'
+
+    assert_requested request_stub
+    assert_current_path registrar_domains_path
+    assert_text 'Nameserver have been successfully added'
+    assert_text 'Affected domains: airport.test, shop.test'
+  end
+
+  def test_adding_nameservers_only_for_scoped_domains
+    request_body = { data: { type: 'nameserver',
+                             id: '',
+                             domains: ['shop.test'],
+                             attributes: { hostname: 'new-ns1.bestnames.test',
+                                           ipv4: %w[192.0.2.55 192.0.2.56],
+                                           ipv6: %w[2001:db8::55 2001:db8::56] } } }
+    request_stub = stub_request(:put, /registrar\/nameservers/).with(body: request_body,
+                                                                     headers: { 'Content-type' => Mime[:json] },
+                                                                     basic_auth: ['test_goodnames', 'testtest'])
+                                                               .to_return(body: { data: {
+                                                                 type: 'nameserver',
+                                                                 id: 'new-ns1.bestnames.test',
+                                                                 affected_domains: ["shop.test"],
+                                                                 skipped_domains: []}}.to_json, status: 200)
+
+    visit registrar_domains_url
+    click_link 'Bulk change'
+    click_link 'Nameserver'
+
+    fill_in 'New hostname', with: 'new-ns1.bestnames.test'
+    fill_in 'ipv4', with: "192.0.2.55\n192.0.2.56"
+    fill_in 'ipv6', with: "2001:db8::55\n2001:db8::56"
+    attach_file :puny_file, Rails.root.join('test', 'fixtures', 'files', 'valid_domains_for_ns_replacement.csv').to_s
+
+    click_on 'Replace/Add nameserver'
+
+    assert_requested request_stub
+    assert_current_path registrar_domains_path
+    assert_text 'Nameserver have been successfully added'
+    assert_text 'Affected domains: shop.test'
   end
 end


### PR DESCRIPTION
close #2158

PUT /repp/v1/registrar/nameservers
{
    "data": {
        "type": "nameserver",
        "domains": ["only.ee", "these.ee", "domains.ee"],
        "attributes": {
            "hostname": "ns2.ams1.domainer.ee",
            "ipv4": ["192.168.1.1"],
            "ipv6": ["2620:119:35::36"]
        }
    }
}

As result nameserver "ns2.ams1.domainer.ee" will be add to next domains: "only.ee", "these.ee", "domains.ee"