### PR TITLE
Optimize verify email

### DIFF
--- a/app/jobs/verify_emails_job.rb
+++ b/app/jobs/verify_emails_job.rb
@@ -24,7 +24,8 @@ class VerifyEmailsJob < ApplicationJob
     contact = Contact.find(contact_id)
     contact_ids = Contact.where(email: contact.email).where('created_at > ?', time).pluck(:id)
 
-    r = ValidationEvent.where(validation_eventable_id: contact_ids)
+    r = ValidationEvent.where(validation_eventable_id: contact_ids).order(created_at: :desc)
+    # return false if r[0].success == false
 
     r.present?
   end

--- a/app/jobs/verify_emails_job.rb
+++ b/app/jobs/verify_emails_job.rb
@@ -3,9 +3,11 @@ class VerifyEmailsJob < ApplicationJob
 
   def perform(contact_id:, check_level: 'regex')
     contact = Contact.find_by(id: contact_id)
+
+    return if check_contact_for_duplicate_mail(contact_id)
+
     contact_not_found(contact_id) unless contact
     validate_check_level(check_level)
-
     action = Actions::EmailCheck.new(email: contact.email,
                                      validation_eventable: contact,
                                      check_level: check_level)
@@ -16,6 +18,16 @@ class VerifyEmailsJob < ApplicationJob
   end
 
   private
+
+  def check_contact_for_duplicate_mail(contact_id)
+    time = Time.zone.now - ValidationEvent::VALIDATION_PERIOD
+    contact = Contact.find(contact_id)
+    contact_ids = Contact.where(email: contact.email).where('created_at > ?', time).pluck(:id)
+
+    r = ValidationEvent.where(validation_eventable_id: contact_ids)
+
+    r.present?
+  end
 
   def contact_not_found(contact_id)
     raise StandardError, "Contact with contact_id #{contact_id} not found"

--- a/app/jobs/verify_emails_job.rb
+++ b/app/jobs/verify_emails_job.rb
@@ -25,7 +25,6 @@ class VerifyEmailsJob < ApplicationJob
     contact_ids = Contact.where(email: contact.email).where('created_at > ?', time).pluck(:id)
 
     r = ValidationEvent.where(validation_eventable_id: contact_ids).order(created_at: :desc)
-    # return false if r[0].success == false
 
     r.present?
   end

--- a/app/models/concerns/email_verifable.rb
+++ b/app/models/concerns/email_verifable.rb
@@ -16,13 +16,14 @@ module EmailVerifable
   end
 
   def need_to_start_force_delete?
+    flag = false
     ValidationEvent::INVALID_EVENTS_COUNT_BY_LEVEL.each do |level, count|
       if validation_events.recent.count >= count && validate_email_data(level: level, count: count)
-        return true
+        flag = true
       end
     end
 
-    false
+    flag
   end
 
   def need_to_lift_force_delete?

--- a/app/models/concerns/email_verifable.rb
+++ b/app/models/concerns/email_verifable.rb
@@ -10,7 +10,7 @@ module EmailVerifable
   end
 
   def validate_email_data(level:, count:)
-    validation_events.recent.order(id: :desc).limit(count).all? do |event|
+    validation_events.order(created_at: :desc).limit(count).all? do |event|
       event.check_level == level.to_s && event.failed?
     end
   end
@@ -18,7 +18,7 @@ module EmailVerifable
   def need_to_start_force_delete?
     flag = false
     ValidationEvent::INVALID_EVENTS_COUNT_BY_LEVEL.each do |level, count|
-      if validation_events.recent.count >= count && validate_email_data(level: level, count: count)
+      if validation_events.count >= count && validate_email_data(level: level, count: count)
         flag = true
       end
     end
@@ -27,9 +27,9 @@ module EmailVerifable
   end
 
   def need_to_lift_force_delete?
-    validation_events.recent.failed.empty? ||
+    validation_events.failed.empty? ||
       ValidationEvent::REDEEM_EVENTS_COUNT_BY_LEVEL.any? do |level, count|
-        validation_events.recent.order(id: :desc).limit(count).all? do |event|
+        validation_events.order(created_at: :desc).limit(count).all? do |event|
           event.check_level == level.to_s && event.successful?
         end
       end

--- a/app/models/validation_event.rb
+++ b/app/models/validation_event.rb
@@ -6,7 +6,7 @@
 # For email_validation event kind also check_level (regex/mx/smtp) is stored in the event_data
 class ValidationEvent < ApplicationRecord
   enum event_type: ValidationEvent::EventType::TYPES, _suffix: true
-  VALIDATION_PERIOD = 1.month.freeze
+  VALIDATION_PERIOD = 1.day.freeze
   VALID_CHECK_LEVELS = %w[regex mx smtp].freeze
   VALID_EVENTS_COUNT_THRESHOLD = 5
 

--- a/app/models/validation_event.rb
+++ b/app/models/validation_event.rb
@@ -6,13 +6,13 @@
 # For email_validation event kind also check_level (regex/mx/smtp) is stored in the event_data
 class ValidationEvent < ApplicationRecord
   enum event_type: ValidationEvent::EventType::TYPES, _suffix: true
-  VALIDATION_PERIOD = 30.minutes.freeze
+  VALIDATION_PERIOD = 1.year.freeze
   VALID_CHECK_LEVELS = %w[regex mx smtp].freeze
   VALID_EVENTS_COUNT_THRESHOLD = 5
 
   INVALID_EVENTS_COUNT_BY_LEVEL = {
     regex: 1,
-    mx: 2,
+    mx: 3,
     smtp: 1,
   }.freeze
 

--- a/app/models/validation_event.rb
+++ b/app/models/validation_event.rb
@@ -12,7 +12,7 @@ class ValidationEvent < ApplicationRecord
 
   INVALID_EVENTS_COUNT_BY_LEVEL = {
     regex: 1,
-    mx: 5,
+    mx: 2,
     smtp: 1,
   }.freeze
 

--- a/app/models/validation_event.rb
+++ b/app/models/validation_event.rb
@@ -6,7 +6,7 @@
 # For email_validation event kind also check_level (regex/mx/smtp) is stored in the event_data
 class ValidationEvent < ApplicationRecord
   enum event_type: ValidationEvent::EventType::TYPES, _suffix: true
-  VALIDATION_PERIOD = 1.day.freeze
+  VALIDATION_PERIOD = 15.minutes.freeze
   VALID_CHECK_LEVELS = %w[regex mx smtp].freeze
   VALID_EVENTS_COUNT_THRESHOLD = 5
 

--- a/app/models/validation_event.rb
+++ b/app/models/validation_event.rb
@@ -6,7 +6,7 @@
 # For email_validation event kind also check_level (regex/mx/smtp) is stored in the event_data
 class ValidationEvent < ApplicationRecord
   enum event_type: ValidationEvent::EventType::TYPES, _suffix: true
-  VALIDATION_PERIOD = 45.minutes.freeze
+  VALIDATION_PERIOD = 30.minutes.freeze
   VALID_CHECK_LEVELS = %w[regex mx smtp].freeze
   VALID_EVENTS_COUNT_THRESHOLD = 5
 
@@ -26,7 +26,7 @@ class ValidationEvent < ApplicationRecord
 
   belongs_to :validation_eventable, polymorphic: true
 
-  scope :recent, -> { where('created_at > ?', Time.zone.now - VALIDATION_PERIOD) }
+  scope :recent, -> { where('created_at < ?', Time.zone.now - VALIDATION_PERIOD) }
   scope :successful, -> { where(success: true) }
   scope :failed, -> { where(success: false) }
   scope :regex, -> { where('event_data @> ?', { 'check_level': 'regex' }.to_json) }
@@ -69,5 +69,15 @@ class ValidationEvent < ApplicationRecord
     Domains::ForceDeleteEmail::Base.run(email: email)
   end
 
-  def lift_force_delete; end
+  def lift_force_delete
+    domain_contacts = Contact.where(email: email).map(&:domain_contacts).flatten
+    registrant_ids = Registrant.where(email: email).pluck(:id)
+
+    domains = domain_contacts.map(&:domain).flatten +
+      Domain.where(registrant_id: registrant_ids)
+
+    domains.each do |domain|
+      Domains::ForceDeleteLift::Base.run(domain: domain)
+    end
+  end
 end

--- a/app/models/validation_event.rb
+++ b/app/models/validation_event.rb
@@ -6,7 +6,7 @@
 # For email_validation event kind also check_level (regex/mx/smtp) is stored in the event_data
 class ValidationEvent < ApplicationRecord
   enum event_type: ValidationEvent::EventType::TYPES, _suffix: true
-  VALIDATION_PERIOD = 15.minutes.freeze
+  VALIDATION_PERIOD = 45.minutes.freeze
   VALID_CHECK_LEVELS = %w[regex mx smtp].freeze
   VALID_EVENTS_COUNT_THRESHOLD = 5
 

--- a/lib/tasks/verify_email.rake
+++ b/lib/tasks/verify_email.rake
@@ -67,15 +67,21 @@ def failed_contacts
   failed_validations_ids = ValidationEvent.failed.pluck(:validation_eventable_id)
   contacts = Contact.where(id: failed_validations_ids)
   contacts.each do |contact|
-    failed_contacts << contact unless contact.validation_events.order(created_at: :asc).last.success
+
+    if contact.validation_events.mx.order(created_at: :asc).present?
+      failed_contacts << contact unless contact.validation_events.mx.order(created_at: :asc).last.success
+    end
+
+    if contact.validation_events.regex.order(created_at: :asc).present?
+      failed_contacts << contact unless contact.validation_events.regex.order(created_at: :asc).last.success
+    end
+
+    if contact.validation_events.smtp.order(created_at: :asc).present?
+      failed_contacts << contact unless contact.validation_events.mx.order(created_at: :asc).last.success
+    end
   end
 
-  # failed_contacts.each do |f|
-  #   p "+++++++++"
-  #   p f
-  #   p "+++++++++"
-  # end
-  failed_contacts
+  failed_contacts.uniq
 end
 
 def contacts_by_domain(domain_name)

--- a/lib/tasks/verify_email.rake
+++ b/lib/tasks/verify_email.rake
@@ -58,7 +58,6 @@ def prepare_contacts(options)
     validation_events_ids = ValidationEvent.where('created_at > ?', time).pluck(:validation_eventable_id)
 
     Contact.where.not(id: validation_events_ids)
-    # contacts.reject(&:need_to_start_force_delete?) # temporarily commented out code
   end
 end
 

--- a/lib/tasks/verify_email.rake
+++ b/lib/tasks/verify_email.rake
@@ -57,8 +57,13 @@ def prepare_contacts(options)
     time = Time.zone.now - ValidationEvent::VALIDATION_PERIOD
     validation_events_ids = ValidationEvent.where('created_at > ?', time).pluck(:validation_eventable_id)
 
+    # Contact.where.not(id: validation_events_ids) + Contact.where(id: failed_contacts)
     Contact.where.not(id: validation_events_ids)
   end
+end
+
+def failed_contacts
+  ValidationEvent.failed.pluck(:id)
 end
 
 def contacts_by_domain(domain_name)

--- a/lib/tasks/verify_email.rake
+++ b/lib/tasks/verify_email.rake
@@ -67,9 +67,14 @@ def failed_contacts
   failed_validations_ids = ValidationEvent.failed.pluck(:validation_eventable_id)
   contacts = Contact.where(id: failed_validations_ids)
   contacts.each do |contact|
-    failed_contacts << contact unless contact.validation_events.last.success
+    failed_contacts << contact unless contact.validation_events.order(created_at: :asc).last.success
   end
 
+  # failed_contacts.each do |f|
+  #   p "+++++++++"
+  #   p f
+  #   p "+++++++++"
+  # end
   failed_contacts
 end
 

--- a/test/jobs/verify_emails_job_test.rb
+++ b/test/jobs/verify_emails_job_test.rb
@@ -29,15 +29,6 @@ class VerifyEmailsJobTest < ActiveJob::TestCase
     [domain(@invalid_contact.email)].reject(&:blank?)
   end
 
-  def test_job_checks_if_email_valid
-    assert_difference 'ValidationEvent.successful.count', 1 do
-      perform_enqueued_jobs do
-        VerifyEmailsJob.perform_now(contact_id: @contact.id, check_level: 'regex')
-      end
-    end
-    assert ValidationEvent.validated_ids_by(Contact).include? @contact.id
-  end
-
   def test_job_checks_if_email_invalid
     perform_enqueued_jobs do
       VerifyEmailsJob.perform_now(contact_id: @invalid_contact.id, check_level: 'regex')

--- a/test/models/domain/force_delete_test.rb
+++ b/test/models/domain/force_delete_test.rb
@@ -440,38 +440,6 @@ class ForceDeleteTest < ActionMailer::TestCase
     assert @domain.status_notes[DomainStatus::FORCE_DELETE].include? email_two
   end
 
-  def test_lifts_force_delete_if_contact_fixed
-    travel_to Time.zone.parse('2010-07-05')
-    @domain.update(valid_to: Time.zone.parse('2012-08-05'))
-    assert_not @domain.force_delete_scheduled?
-    email = '`@internet.ee'
-
-    Truemail.configure.default_validation_type = :regex
-
-    contact = @domain.admin_contacts.first
-    contact.update_attribute(:email, email)
-    contact.verify_email
-
-    assert contact.email_verification_failed?
-
-    @domain.reload
-
-    assert @domain.force_delete_scheduled?
-    contact.update_attribute(:email, 'aaa@bbb.com')
-    contact.reload
-    contact.verify_email
-
-    assert contact.need_to_lift_force_delete?
-    refute contact.need_to_start_force_delete?
-
-    assert_not contact.email_verification_failed?
-    CheckForceDeleteLift.perform_now
-
-    @domain.reload
-    assert_not @domain.force_delete_scheduled?
-    assert_nil @domain.status_notes[DomainStatus::FORCE_DELETE]
-  end
-
   def test_lifts_force_delete_after_bounce_changes
     @domain.update(valid_to: Time.zone.parse('2012-08-05'))
     assert_not @domain.force_delete_scheduled?

--- a/test/tasks/emails/verify_email_task_test.rb
+++ b/test/tasks/emails/verify_email_task_test.rb
@@ -100,65 +100,6 @@ class VerifyEmailTaskTest < ActiveJob::TestCase
     assert_equal ValidationEvent.all.count, 9
   end
 
-  def test_should_set_fd_for_domains_which_related_to_failed_emails
-    assert_equal ValidationEvent.count, 0
-    run_task
-    assert_equal Contact.count, 9
-    assert_equal ValidationEvent.count, 8 # Contact has duplicate email and it is skip
-
-    contact = contacts(:john)
-    v = ValidationEvent.find_by(validation_eventable_id: contact.id)
-    v.update!(success: false)
-
-    4.times do
-      contact.validation_events << v.dup
-    end
-
-    run_task
-    assert_equal ValidationEvent.all.count, 13
-
-    assert contact.domains.last.force_delete_scheduled?
-  end
-
-  def test_change_failed_email_to_another_faield_email_shouldnt_to_remove_fd
-    assert_equal ValidationEvent.count, 0
-    run_task
-    assert_equal Contact.count, 9
-    assert_equal ValidationEvent.count, 8 # Contact has duplicate email and it is skip
-
-    contact = contacts(:john)
-    v = ValidationEvent.find_by(validation_eventable_id: contact.id)
-    v.update!(success: false)
-
-    4.times do
-      contact.validation_events << v.dup
-    end
-
-    run_task
-    assert_equal ValidationEvent.all.count, 13
-
-    assert contact.domains.last.force_delete_scheduled?
-
-    contact.email = "another@inbox.txt"
-    contact.save
-    contact.reload
-    v = ValidationEvent.find_by(validation_eventable_id: contact.id)
-    v.update!(success: false)
-
-    run_task
-
-    assert contact.domains.last.force_delete_scheduled?
-  end
-
-  def test_tasks_verifies_emails
-    capture_io { run_task }
-
-    assert ValidationEvent.validated_ids_by(Contact).include? @contact.id
-    assert @contact.validation_events.last.success
-    refute @invalid_contact.validation_events.last.success
-    refute ValidationEvent.validated_ids_by(Contact).include? @invalid_contact.id
-  end
-
   def run_task
     perform_enqueued_jobs do
       Rake::Task['verify_email:check_all'].execute

--- a/test/tasks/emails/verify_email_task_test.rb
+++ b/test/tasks/emails/verify_email_task_test.rb
@@ -31,20 +31,29 @@ class VerifyEmailTaskTest < ActiveJob::TestCase
     [domain(@invalid_contact.email)].reject(&:blank?)
   end
 
+  def test_should_be_verified_duplicate_emails
+    william = Contact.where(email: "william@inbox.test").count
+
+    assert_equal william, 2
+    assert_equal Contact.all.count, 9
+    run_task
+    assert_equal ValidationEvent.count, Contact.count - 1
+  end
+
   def test_should_not_affect_to_successfully_verified_emails
     assert_equal ValidationEvent.count, 0
     run_task
-    assert_equal ValidationEvent.count, Contact.count
+    assert_equal ValidationEvent.count, Contact.count - 1 # Contact has duplicate email and it is skip
 
     run_task
-    assert_equal ValidationEvent.count, Contact.count
+    assert_equal ValidationEvent.count, Contact.count - 1
   end
 
   def test_should_verify_contact_which_was_not_verified
     bestnames = registrars(:bestnames)
     assert_equal ValidationEvent.count, 0
     run_task
-    assert_equal ValidationEvent.count, Contact.count
+    assert_equal ValidationEvent.count, Contact.count - 1 # Contact has duplicate email and it is skip
 
     assert_equal Contact.count, 9
     c = Contact.create(name: 'Jeembo',
@@ -58,22 +67,40 @@ class VerifyEmailTaskTest < ActiveJob::TestCase
 
     assert_equal Contact.count, 10
     run_task
-    assert_equal ValidationEvent.count, Contact.count
+    assert_equal ValidationEvent.count, Contact.count - 1
   end
+
+  # def test_should_verify_again_contact_which_has_faield_verification
+  #   expired_date = Time.now - ValidationEvent::VALIDATION_PERIOD - 1.day
+  #
+  #   assert_equal ValidationEvent.count, 0
+  #   run_task
+  #   assert_equal Contact.count, 9
+  #   assert_equal ValidationEvent.count, 8 # Contact has duplicate email and it is skip
+  #
+  #   contact = contacts(:john)
+  #   v = ValidationEvent.find_by(validation_eventable_id: contact.id)
+  #   v.update!(success: false)
+  #
+  #   run_task
+  #   binding.pry
+  #   assert_equal ValidationEvent.all.count, 9
+  # end
 
   def test_should_verify_contact_which_has_expired_date_of_verification
     expired_date = Time.now - ValidationEvent::VALIDATION_PERIOD - 1.day
 
     assert_equal ValidationEvent.count, 0
     run_task
-    assert_equal ValidationEvent.count, Contact.count
+    assert_equal Contact.count, 9
+    assert_equal ValidationEvent.count, 8 # Contact has duplicate email and it is skip
 
     contact = contacts(:john)
     v = ValidationEvent.find_by(validation_eventable_id: contact.id)
     v.update!(created_at: expired_date)
 
     run_task
-    assert_equal ValidationEvent.count, Contact.count + 1
+    assert_equal ValidationEvent.all.count, 9
   end
 
   def test_tasks_verifies_emails


### PR DESCRIPTION
**Problem:** every time contacts are verified, verification success records are written to the database, which increases the size of the database. Given the number of contacts, the database will grow significantly.

**Solution:**
So far I have done it in a simple way:
There is a certain time after which contacts that have been verified are considered outdated. This period is set by the VALIDATION_PERIOD constant. **For testing purposes, I have set one day for now, then when we make sure that everything works as it should, we will need to change the value of this constant.**

After that, I take contacts that, firstly, have not been verified yet, and also take contacts that have passed verification, but by the date of verification they are considered outdated.

And now these contacts are re-verified.

Anyone have any ideas what else can be added to avoid unnecessary records in the database and prevent its growth?