### PR TITLE
added endpoints to demo registry for accr results

### DIFF
--- a/app/controllers/admin/api_users_controller.rb
+++ b/app/controllers/admin/api_users_controller.rb
@@ -17,8 +17,7 @@ module Admin
 
       if @api_user.valid?
         @api_user.save!
-        redirect_to admin_registrar_api_user_path(@api_user.registrar, @api_user),
-                    notice: t('.created')
+        redirect_to admin_registrar_api_user_path(@api_user.registrar, @api_user), notice: t('.created')
       else
         render 'new'
       end
@@ -35,8 +34,7 @@ module Admin
 
       if @api_user.valid?
         @api_user.save!
-        redirect_to admin_registrar_api_user_path(@api_user.registrar, @api_user),
-                    notice: t('.updated')
+        redirect_to admin_registrar_api_user_path(@api_user.registrar, @api_user), notice: t('.updated')
       else
         render 'edit'
       end
@@ -50,7 +48,7 @@ module Admin
     def set_test_date_to_api_user
       user_api = User.find(params[:user_api_id])
 
-      uri = URI.parse((ENV['registry_demo_registrar_api_user_url'] || 'http://testapi.test') + "?username=#{user_api.username}&identity_code=#{user_api.identity_code}")
+      uri = URI.parse((ENV['registry_demo_registrar_api_user_url']) + "?username=#{user_api.username}&identity_code=#{user_api.identity_code}")
 
       response = base_get_request(uri: uri, port: ENV['registry_demo_registrar_port'])
 
@@ -58,9 +56,8 @@ module Admin
         result = JSON.parse(response.body)
         demo_user_api = result['user_api']
 
-        Actions::RecordDateOfTest.record_result_to_api_user(
-                                  api_user:user_api,
-                                  date: demo_user_api['accreditation_date']) unless demo_user_api.empty?
+        Actions::RecordDateOfTest.record_result_to_api_user(api_user:user_api,
+                                                            date: demo_user_api['accreditation_date']) unless demo_user_api.empty?
         return redirect_to request.referrer, notice: 'User Api found'
       else
         return redirect_to request.referrer, notice: 'User Api no found or not accriditated yet'

--- a/app/controllers/admin/api_users_controller.rb
+++ b/app/controllers/admin/api_users_controller.rb
@@ -50,7 +50,7 @@ module Admin
     def set_test_date_to_api_user
       user_api = User.find(params[:user_api_id])
 
-      uri = URI.parse(ENV['registry_demo_registrar_api_user_url'] + "?username=#{user_api.username}&identity_code=#{user_api.identity_code}")
+      uri = URI.parse((ENV['registry_demo_registrar_api_user_url'] || 'testapi.test') + "?username=#{user_api.username}&identity_code=#{user_api.identity_code}")
 
       response = base_get_request(uri: uri, port: ENV['registry_demo_registrar_port'])
 

--- a/app/controllers/admin/api_users_controller.rb
+++ b/app/controllers/admin/api_users_controller.rb
@@ -47,7 +47,45 @@ module Admin
       redirect_to admin_registrar_path(@api_user.registrar), notice: t('.deleted')
     end
 
+    def set_test_date_to_api_user
+      user_api = User.find(params[:user_api_id])
+
+      uri = URI.parse(ENV['registry_demo_registrar_api_user_url'] + "?username=#{user_api.username}&identity_code=#{user_api.identity_code}")
+
+      response = base_get_request(uri: uri, port: ENV['registry_demo_registrar_port'])
+
+      if response.code == "200"
+        result = JSON.parse(response.body)
+        demo_user_api = result['user_api']
+
+        Actions::RecordDateOfTest.record_result_to_api_user(
+                                  api_user:user_api,
+                                  date: demo_user_api['accreditation_date']) unless demo_user_api.empty?
+        return redirect_to request.referrer, notice: 'User Api found'
+      else
+        return redirect_to request.referrer, notice: 'User Api no found or not accriditated yet'
+      end
+
+      redirect_to request.referrer, notice: 'Something goes wrong'
+    end
+
+    def remove_test_date_to_api_user
+      user_api = User.find(params[:user_api_id])
+      user_api.accreditation_date = nil
+      user_api.accreditation_expire_date = nil
+      user_api.save
+      
+      redirect_to request.referrer
+    end
+
     private
+
+    def base_get_request(uri:, port:)
+      http = Net::HTTP.new(uri.host, port)
+      req = Net::HTTP::Get.new(uri.request_uri)
+
+      http.request(req)
+    end
 
     def api_user_params
       params.require(:api_user).permit(:username, :plain_text_password, :active,

--- a/app/controllers/admin/api_users_controller.rb
+++ b/app/controllers/admin/api_users_controller.rb
@@ -50,7 +50,7 @@ module Admin
     def set_test_date_to_api_user
       user_api = User.find(params[:user_api_id])
 
-      uri = URI.parse((ENV['registry_demo_registrar_api_user_url'] || 'testapi.test') + "?username=#{user_api.username}&identity_code=#{user_api.identity_code}")
+      uri = URI.parse((ENV['registry_demo_registrar_api_user_url'] || 'http://testapi.test') + "?username=#{user_api.username}&identity_code=#{user_api.identity_code}")
 
       response = base_get_request(uri: uri, port: ENV['registry_demo_registrar_port'])
 
@@ -74,7 +74,7 @@ module Admin
       user_api.accreditation_date = nil
       user_api.accreditation_expire_date = nil
       user_api.save
-      
+
       redirect_to request.referrer
     end
 

--- a/app/controllers/admin/registrars_controller.rb
+++ b/app/controllers/admin/registrars_controller.rb
@@ -60,7 +60,7 @@ module Admin
     def set_test_date
       registrar = Registrar.find(params[:registrar_id])
 
-      uri = URI.parse((ENV['registry_demo_registrar_results_url'] || 'testapi.test') + "?registrar_name=#{registrar.name}")
+      uri = URI.parse((ENV['registry_demo_registrar_results_url'] || 'http://testapi.test') + "?registrar_name=#{registrar.name}")
 
       response = base_get_request(uri: uri, port: ENV['registry_demo_registrar_port'])
 

--- a/app/controllers/admin/registrars_controller.rb
+++ b/app/controllers/admin/registrars_controller.rb
@@ -93,8 +93,8 @@ module Admin
       return redirect_to request.referrer, notice: 'Registrar found, but not accreditated yet' if registrar_users.empty?
 
       registrar_users.each do |api|
-        a = ApiUser.find_by(username: api.username, identity_code: api.identity_code)
-        Actions::RecordDateOfTest.record_result_to_api_user(a, api.accreditation_date) unless a.nil?
+        a = ApiUser.find_by(username: api['username'], identity_code: api['identity_code'])
+        Actions::RecordDateOfTest.record_result_to_api_user(api_user: a, date: api['accreditation_date']) unless a.nil?
       end
 
       redirect_to request.referrer, notice: 'Registrar found'

--- a/app/controllers/admin/registrars_controller.rb
+++ b/app/controllers/admin/registrars_controller.rb
@@ -1,3 +1,5 @@
+require 'net/http'
+
 module Admin
   class RegistrarsController < BaseController  # rubocop:disable Metrics/ClassLength
     load_and_authorize_resource
@@ -55,7 +57,55 @@ module Admin
       end
     end
 
+    def set_test_date
+      registrar = Registrar.find(params[:registrar_id])
+
+      uri = URI.parse(ENV['registry_demo_registrar_results_url'] + "?registrar_name=#{registrar.name}")
+
+      response = base_get_request(uri: uri, port: ENV['registry_demo_registrar_port'])
+
+      if response.code == "200"
+        return record_result_for_each_api_user(response: response)
+      else
+        return redirect_to request.referrer, notice: 'Registrar no found'
+      end
+
+      redirect_to request.referrer, notice: 'Something goes wrong'
+    end
+
+    def remove_test_date
+      registrar = Registrar.find(params[:registrar_id])
+      registrar.api_users.each do |api|
+        api.accreditation_date = nil
+        api.accreditation_expire_date = nil
+        api.save
+      end
+
+      redirect_to request.referrer
+    end
+
     private
+
+    def record_result_for_each_api_user(response:)
+      result = JSON.parse(response.body)
+      registrar_users = result['registrar_users']
+
+      return redirect_to request.referrer, notice: 'Registrar found, but not accreditated yet' if registrar_users.empty?
+
+      registrar_users.each do |api|
+        a = ApiUser.find_by(username: api.username, identity_code: api.identity_code)
+        Actions::RecordDateOfTest.record_result_to_api_user(a, api.accreditation_date) unless a.nil?
+      end
+
+      redirect_to request.referrer, notice: 'Registrar found'
+    end
+
+    def base_get_request(uri:, port:)
+      http = Net::HTTP.new(uri.host, port)
+      req = Net::HTTP::Get.new(uri.request_uri)
+
+      http.request(req)
+    end
 
     def filter_by_status
       case params[:status]

--- a/app/controllers/admin/registrars_controller.rb
+++ b/app/controllers/admin/registrars_controller.rb
@@ -60,17 +60,17 @@ module Admin
     def set_test_date
       registrar = Registrar.find(params[:registrar_id])
 
-      uri = URI.parse((ENV['registry_demo_registrar_results_url'] || 'http://testapi.test') + "?registrar_name=#{registrar.name}")
+      uri = URI.parse((ENV['registry_demo_registrar_results_url']) + "?registrar_name=#{registrar.name}")
 
       response = base_get_request(uri: uri, port: ENV['registry_demo_registrar_port'])
 
       if response.code == "200"
         return record_result_for_each_api_user(response: response)
       else
-        return redirect_to request.referrer, notice: 'Registrar no found'
+        return redirect_to request.referer, notice: 'Registrar no found'
       end
 
-      redirect_to request.referrer, notice: 'Something goes wrong'
+      redirect_to request.referer, notice: 'Something goes wrong'
     end
 
     def remove_test_date
@@ -81,7 +81,7 @@ module Admin
         api.save
       end
 
-      redirect_to request.referrer
+      redirect_to request.referer
     end
 
     private
@@ -90,14 +90,14 @@ module Admin
       result = JSON.parse(response.body)
       registrar_users = result['registrar_users']
 
-      return redirect_to request.referrer, notice: 'Registrar found, but not accreditated yet' if registrar_users.empty?
+      return redirect_to request.referer, notice: 'Registrar found, but not accreditated yet' if registrar_users.empty?
 
       registrar_users.each do |api|
         a = ApiUser.find_by(username: api['username'], identity_code: api['identity_code'])
         Actions::RecordDateOfTest.record_result_to_api_user(api_user: a, date: api['accreditation_date']) unless a.nil?
       end
 
-      redirect_to request.referrer, notice: 'Registrar found'
+      redirect_to request.referer, notice: 'Registrar found'
     end
 
     def base_get_request(uri:, port:)

--- a/app/controllers/admin/registrars_controller.rb
+++ b/app/controllers/admin/registrars_controller.rb
@@ -60,7 +60,7 @@ module Admin
     def set_test_date
       registrar = Registrar.find(params[:registrar_id])
 
-      uri = URI.parse(ENV['registry_demo_registrar_results_url'] + "?registrar_name=#{registrar.name}")
+      uri = URI.parse((ENV['registry_demo_registrar_results_url'] || 'testapi.test') + "?registrar_name=#{registrar.name}")
 
       response = base_get_request(uri: uri, port: ENV['registry_demo_registrar_port'])
 

--- a/app/controllers/api/v1/accreditation_center/base_controller.rb
+++ b/app/controllers/api/v1/accreditation_center/base_controller.rb
@@ -3,7 +3,7 @@ require 'auth_token/auth_token_decryptor'
 module Api
   module V1
     module AccreditationCenter
-      if Rails.env.development? || Rails.env.staging? || Rails.env.test?
+      if Feature.allow_accr_endspoints?
         class BaseController < ActionController::API
           rescue_from ActiveRecord::RecordNotFound, with: :show_not_found_error
           rescue_from ActiveRecord::RecordInvalid, with: :show_invalid_record_error

--- a/app/controllers/api/v1/accreditation_center/base_controller.rb
+++ b/app/controllers/api/v1/accreditation_center/base_controller.rb
@@ -3,24 +3,26 @@ require 'auth_token/auth_token_decryptor'
 module Api
   module V1
     module AccreditationCenter
-      class BaseController < ActionController::API
-        rescue_from ActiveRecord::RecordNotFound, with: :show_not_found_error
-        rescue_from ActiveRecord::RecordInvalid, with: :show_invalid_record_error
-        rescue_from(ActionController::ParameterMissing) do |parameter_missing_exception|
-          error = {}
-          error[parameter_missing_exception.param] = ['parameter is required']
-          response = { errors: [error] }
-          render json: response, status: :unprocessable_entity
-        end
+      if Rails.env.development? || Rails.env.staging? || Rails.env.test?
+        class BaseController < ActionController::API
+          rescue_from ActiveRecord::RecordNotFound, with: :show_not_found_error
+          rescue_from ActiveRecord::RecordInvalid, with: :show_invalid_record_error
+          rescue_from(ActionController::ParameterMissing) do |parameter_missing_exception|
+            error = {}
+            error[parameter_missing_exception.param] = ['parameter is required']
+            response = { errors: [error] }
+            render json: response, status: :unprocessable_entity
+          end
 
-        private
+          private
 
-        def show_not_found_error
-          render json: { errors: [{ base: ['Not found'] }] }, status: :not_found
-        end
+          def show_not_found_error
+            render json: { errors: [{ base: ['Not found'] }] }, status: :not_found
+          end
 
-        def show_invalid_record_error(exception)
-          render json: { errors: exception.record.errors }, status: :bad_request
+          def show_invalid_record_error(exception)
+            render json: { errors: exception.record.errors }, status: :bad_request
+          end
         end
       end
     end

--- a/app/controllers/api/v1/accreditation_center/results_controller.rb
+++ b/app/controllers/api/v1/accreditation_center/results_controller.rb
@@ -1,0 +1,40 @@
+require 'serializers/repp/contact'
+
+module Api
+  module V1
+    module AccreditationCenter
+      class ResultsController < ::Api::V1::AccreditationCenter::BaseController
+        def show
+          accr_users = []
+          registrar = Registrar.find_by(name: params[:registrar_name])
+
+          return render json: { errors: 'Registrar not found' }, status: :not_found if registrar.nil?
+
+          registrar.api_users.where.not(accreditation_date: nil).each do |u|
+            accr_users << u
+          end
+
+          render json: { code: 1000, registrar_users: accr_users }
+        end
+
+        def show_api_user
+          user_api = User.find_by(username: params[:username], identity_code: params[:identity_code])
+
+          return render json: { errors: 'User not found' }, status: :not_found if user_api.nil?
+
+          return render json: { errors: 'No accreditated yet' }, status: :not_found if user_api.accreditation_date.nil?
+
+          render json: { code: 1000, user_api: user_api }
+        end
+
+        def list_accreditated_api_users
+          users = User.where.not(accreditation_date: nil)
+
+          return render json: { errors: 'Accreditated users not found' }, status: :not_found if users.empty?
+
+          render json: { code: 1000, users: users }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/repp/v1/registrar/accreditation_info_controller.rb
+++ b/app/controllers/repp/v1/registrar/accreditation_info_controller.rb
@@ -1,7 +1,7 @@
 module Repp
   module V1
     module Registrar
-      if Rails.env.development? || Rails.env.staging?
+      if Rails.env.development? || Rails.env.staging? || Rails.env.test?
         class AccreditationInfoController < BaseController
           api :GET, 'repp/v1/registrar/accreditation/get_info'
           desc 'check login user and return data'

--- a/app/controllers/repp/v1/registrar/accreditation_info_controller.rb
+++ b/app/controllers/repp/v1/registrar/accreditation_info_controller.rb
@@ -1,36 +1,38 @@
 module Repp
   module V1
     module Registrar
-      class AccreditationInfoController < BaseController
-        api :GET, 'repp/v1/registrar/accreditation/get_info'
-        desc 'check login user and return data'
+      if Rails.env.development? || Rails.env.staging?
+        class AccreditationInfoController < BaseController
+          api :GET, 'repp/v1/registrar/accreditation/get_info'
+          desc 'check login user and return data'
 
-        def index
-          login = current_user
-          registrar = current_user.registrar
+          def index
+            login = current_user
+            registrar = current_user.registrar
 
-          # rubocop:disable Style/AndOr
-          render_success(data: nil) and return unless login
-          # rubocop:enable Style/AndOr
+            # rubocop:disable Style/AndOr
+            render_success(data: nil) and return unless login
+            # rubocop:enable Style/AndOr
 
-          data = set_values_to_data(login: login, registrar: registrar)
+            data = set_values_to_data(login: login, registrar: registrar)
 
-          render_success(data: data)
-        end
+            render_success(data: data)
+          end
 
-        private
+          private
 
-        def set_values_to_data(login:, registrar:)
-          data = login.as_json(only: %i[id
-                                        username
-                                        name
-                                        uuid
-                                        roles
-                                        accreditation_date
-                                        accreditation_expire_date])
-          data[:registrar_name] = registrar.name
-          data[:registrar_reg_no] = registrar.reg_no
-          data
+          def set_values_to_data(login:, registrar:)
+            data = login.as_json(only: %i[id
+                                          username
+                                          name
+                                          uuid
+                                          roles
+                                          accreditation_date
+                                          accreditation_expire_date])
+            data[:registrar_name] = registrar.name
+            data[:registrar_reg_no] = registrar.reg_no
+            data
+          end
         end
       end
     end

--- a/app/controllers/repp/v1/registrar/accreditation_info_controller.rb
+++ b/app/controllers/repp/v1/registrar/accreditation_info_controller.rb
@@ -1,7 +1,7 @@
 module Repp
   module V1
     module Registrar
-      if Rails.env.development? || Rails.env.staging? || Rails.env.test?
+      if Feature.allow_accr_endspoints?
         class AccreditationInfoController < BaseController
           api :GET, 'repp/v1/registrar/accreditation/get_info'
           desc 'check login user and return data'

--- a/app/controllers/repp/v1/registrar/accreditation_results_controller.rb
+++ b/app/controllers/repp/v1/registrar/accreditation_results_controller.rb
@@ -1,7 +1,7 @@
 module Repp
   module V1
     module Registrar
-      if Rails.env.development? || Rails.env.staging? || Rails.env.test?
+      if Feature.allow_accr_endspoints?
         class AccreditationResultsController < ActionController::API
           before_action :authenticate_shared_key
 

--- a/app/controllers/repp/v1/registrar/accreditation_results_controller.rb
+++ b/app/controllers/repp/v1/registrar/accreditation_results_controller.rb
@@ -1,30 +1,31 @@
 module Repp
   module V1
     module Registrar
-      class AccreditationResultsController < ActionController::API
-        before_action :authenticate_shared_key
+      if Rails.env.development? || Rails.env.staging?
+        class AccreditationResultsController < ActionController::API
+          before_action :authenticate_shared_key
 
         TEMPORARY_SECRET_KEY = ENV['accreditation_secret'].freeze
         EXPIRE_DEADLINE = 15.minutes.freeze
 
-        api :POST, 'repp/v1/registrar/accreditation/push_results'
-        desc 'added datetime results'
+          api :POST, 'repp/v1/registrar/accreditation/push_results'
+          desc 'added datetime results'
 
-        def create
-          username = params[:accreditation_result][:username]
-          result = params[:accreditation_result][:result]
+          def create
+            username = params[:accreditation_result][:username]
+            result = params[:accreditation_result][:result]
 
-          record_accreditation_result(username, result) if result
-        rescue ActiveRecord::RecordNotFound
-          record_not_found(username)
-        end
+            record_accreditation_result(username, result) if result
+          rescue ActiveRecord::RecordNotFound
+            record_not_found(username)
+          end
 
-        private
+          private
 
-        def record_accreditation_result(username, result)
-          user = ApiUser.find_by(username: username)
+          def record_accreditation_result(username, result)
+            user = ApiUser.find_by(username: username)
 
-          raise ActiveRecord::RecordNotFound if user.nil?
+            raise ActiveRecord::RecordNotFound if user.nil?
 
           user.accreditation_date = DateTime.current
           user.accreditation_expire_date = user.accreditation_date + EXPIRE_DEADLINE
@@ -55,26 +56,27 @@ module Repp
           end
         end
 
-        def authenticate_shared_key
-          api_key = "Basic #{TEMPORARY_SECRET_KEY}"
-          render_failed unless api_key == request.authorization
-        end
+          def authenticate_shared_key
+            api_key = "Basic #{TEMPORARY_SECRET_KEY}"
+            render_failed unless api_key == request.authorization
+          end
 
-        def record_not_found(username)
-          @response = { code: 2303, message: "Object '#{username}' does not exist" }
-          render(json: @response)
-        end
+          def record_not_found(username)
+            @response = { code: 2303, message: "Object '#{username}' does not exist" }
+            render(json: @response)
+          end
 
-        def render_failed
-          @response = { code: 2202, message: 'Invalid authorization information' }
-          render(json: @response, status: :unauthorized)
-        end
+          def render_failed
+            @response = { code: 2202, message: 'Invalid authorization information' }
+            render(json: @response, status: :unauthorized)
+          end
 
-        def render_success(code: nil, message: nil, data: nil)
-          @response = { code: code || 1000, message: message || 'Command completed successfully',
-                        data: data || {} }
+          def render_success(code: nil, message: nil, data: nil)
+            @response = { code: code || 1000, message: message || 'Command completed successfully',
+                          data: data || {} }
 
-          render(json: @response, status: :ok)
+            render(json: @response, status: :ok)
+          end
         end
       end
     end

--- a/app/controllers/repp/v1/registrar/accreditation_results_controller.rb
+++ b/app/controllers/repp/v1/registrar/accreditation_results_controller.rb
@@ -1,7 +1,7 @@
 module Repp
   module V1
     module Registrar
-      if Rails.env.development? || Rails.env.staging?
+      if Rails.env.development? || Rails.env.staging? || Rails.env.test?
         class AccreditationResultsController < ActionController::API
           before_action :authenticate_shared_key
 

--- a/app/interactions/actions/record_date_of_test.rb
+++ b/app/interactions/actions/record_date_of_test.rb
@@ -1,0 +1,22 @@
+module Actions
+  module RecordDateOfTest
+    extend self
+
+    TEST_DEADLINE = 1.year.freeze
+
+    def record_result_to_api_user(api_user:, date:)
+      p "+++++++++++"
+      p api_user
+      p "-----------"
+      p DateTime.parse(date)
+      p "+++++++++++"
+
+      api_user.accreditation_date = date
+      api_user.accreditation_expire_date = api_user.accreditation_date + TEST_DEADLINE
+      api_user.save
+
+      # api_user.update(accreditation_date: date,
+      #                 accreditation_expire_date: DateTime.parse(date) + TEST_DEADLINE)
+    end
+  end
+end

--- a/app/interactions/actions/record_date_of_test.rb
+++ b/app/interactions/actions/record_date_of_test.rb
@@ -5,18 +5,9 @@ module Actions
     TEST_DEADLINE = 1.year.freeze
 
     def record_result_to_api_user(api_user:, date:)
-      p "+++++++++++"
-      p api_user
-      p "-----------"
-      p DateTime.parse(date)
-      p "+++++++++++"
-
       api_user.accreditation_date = date
       api_user.accreditation_expire_date = api_user.accreditation_date + TEST_DEADLINE
       api_user.save
-
-      # api_user.update(accreditation_date: date,
-      #                 accreditation_expire_date: DateTime.parse(date) + TEST_DEADLINE)
     end
   end
 end

--- a/app/jobs/sync_accredited_users_job.rb
+++ b/app/jobs/sync_accredited_users_job.rb
@@ -1,22 +1,11 @@
 class SyncAccreditedUsersJob < ApplicationJob
   def perform
-  #   apiusers_from_test = Actions::GetAccrResultsFromAnotherDb.list_of_accredated_users
-
-  #   return if apiusers_from_test.nil?
-
-  #   apiusers_from_test.each do |api|
-  #     a = ApiUser.find_by(username: api.username, identity_code: api.identity_code)
-  #     Actions::RecordDateOfTest.record_result_to_api_user(a, api.accreditation_date) unless a.nil?
-  #   end
     uri = URI.parse(ENV['registry_demo_accredited_users_url'])
-
     response = base_get_request(uri: uri, port: ENV['registry_demo_registrar_port'])
 
-    if response.code == "200"
+    if response.code == '200'
       result = JSON.parse(response.body)
-      users = result['users']
-
-      users.each do |api|
+      result['users'].each do |api|
         a = ApiUser.find_by(username: api.username, identity_code: api.identity_code)
         Actions::RecordDateOfTest.record_result_to_api_user(a, api.accreditation_date) unless a.nil?
       end
@@ -24,7 +13,7 @@ class SyncAccreditedUsersJob < ApplicationJob
       logger.warn 'User not found'
     end
 
-    return
+    nil
   end
 
   private

--- a/app/jobs/sync_accredited_users_job.rb
+++ b/app/jobs/sync_accredited_users_job.rb
@@ -1,0 +1,38 @@
+class SyncAccreditedUsersJob < ApplicationJob
+  def perform
+  #   apiusers_from_test = Actions::GetAccrResultsFromAnotherDb.list_of_accredated_users
+
+  #   return if apiusers_from_test.nil?
+
+  #   apiusers_from_test.each do |api|
+  #     a = ApiUser.find_by(username: api.username, identity_code: api.identity_code)
+  #     Actions::RecordDateOfTest.record_result_to_api_user(a, api.accreditation_date) unless a.nil?
+  #   end
+    uri = URI.parse(ENV['registry_demo_accredited_users_url'])
+
+    response = base_get_request(uri: uri, port: ENV['registry_demo_registrar_port'])
+
+    if response.code == "200"
+      result = JSON.parse(response.body)
+      users = result['users']
+
+      users.each do |api|
+        a = ApiUser.find_by(username: api.username, identity_code: api.identity_code)
+        Actions::RecordDateOfTest.record_result_to_api_user(a, api.accreditation_date) unless a.nil?
+      end
+    else
+      logger.warn 'User not found'
+    end
+
+    return
+  end
+
+  private
+
+  def base_get_request(uri:, port:)
+    http = Net::HTTP.new(uri.host, port)
+    req = Net::HTTP::Get.new(uri.request_uri)
+
+    http.request(req)
+  end
+end

--- a/app/models/api_user.rb
+++ b/app/models/api_user.rb
@@ -56,6 +56,16 @@ class ApiUser < User
     username
   end
 
+  def accredited?
+    !accreditation_date.nil?
+  end
+
+  def accreditation_expired?
+    return false if accreditation_expire_date.nil?
+
+    accreditation_expire_date < Time.zone.now
+  end
+
   def unread_notifications
     registrar.notifications.unread
   end

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -4,4 +4,18 @@ class Feature
 
     ENV['billing_system_integrated'] || false
   end
+  # def self.obj_and_extensions_statuses_enabled?
+  #   return false if ENV['obj_and_extensions_prohibited'] == 'false'
+  #
+  #   ENV['obj_and_extensions_prohibited'] || false
+  # end
+  #
+  # def self.enable_lock_domain_with_new_statuses?
+  #   return false if ENV['enable_lock_domain_with_new_statuses'] == 'false'
+  #
+  #   ENV['enable_lock_domain_with_new_statuses'] || false
+  # end
+  def self.allow_accr_endspoints?
+    ENV['allow_accr_endspoints'] == 'true'
+  end
 end

--- a/app/models/registrar.rb
+++ b/app/models/registrar.rb
@@ -190,6 +190,16 @@ class Registrar < ApplicationRecord # rubocop:disable Metrics/ClassLength
     white_ips.api.include_ip?(ip)
   end
 
+  def accredited?
+    api_users.any? do |a|
+      return true unless a.accreditation_date.nil?
+    end
+  end
+
+  def accreditation_expired?
+    api_users.all? { |api| api.accreditation_expired? }
+  end
+
   # Audit log is needed, therefore no raw SQL
   def replace_nameservers(hostname, new_attributes, domains: [])
     transaction do

--- a/app/views/admin/api_users/_api_user.html.erb
+++ b/app/views/admin/api_users/_api_user.html.erb
@@ -2,4 +2,16 @@
     <td><%= link_to api_user, admin_registrar_api_user_path(api_user.registrar, api_user) %></td>
     <td><%= link_to api_user.registrar, admin_registrar_path(api_user.registrar) %></td>
     <td><%= api_user.active %></td>
+    <td style="text-align: center;">
+
+        <% if !api_user.accredited? || api_user.accreditation_expired? %>
+            <%= button_to t(:set_test_btn),
+                          { controller: 'api_users', action: 'set_test_date_to_api_user', user_api_id: api_user.id },
+                          { method: :post, class: 'btn btn-primary'} %>
+        <% else %>
+            <%= button_to t(:remove_test_btn),
+                          { controller: 'api_users', action: 'remove_test_date_to_api_user', user_api_id: api_user.id },
+                          { method: :post, class: 'btn btn-danger'} %>
+        <% end %>
+    </td>
 </tr>

--- a/app/views/admin/api_users/index.html.erb
+++ b/app/views/admin/api_users/index.html.erb
@@ -10,14 +10,17 @@
             <table class="table table-hover table-bordered table-condensed">
                 <thead>
                     <tr>
-                        <th class="col-xs-2">
+                        <th class="col-xs-3">
                             <%= sort_link(@q, 'username') %>
                         </th>
-                        <th class="col-xs-2">
+                        <th class="col-xs-3">
                             <%= sort_link(@q, 'registrar_name', Registrar.model_name.human) %>
                         </th>
-                        <th class="col-xs-2">
+                        <th class="col-xs-3">
                             <%= sort_link(@q, 'active', ApiUser.human_attribute_name(:active)) %>
+                        </th>
+                        <th class="col-xs-1">
+                            Test status
                         </th>
                     </tr>
                 </thead>

--- a/app/views/admin/api_users/show.html.erb
+++ b/app/views/admin/api_users/show.html.erb
@@ -6,12 +6,12 @@
 </ol>
 
 <div class="page-header">
-    <div class="row">
+    <div class="row" style="display: flex; flex-direction: row; align-items: baseline;">
         <div class="col-sm-8">
             <h1><%= @api_user.username %></h1>
         </div>
 
-        <div class="col-sm-4 text-right">
+        <div class="col-sm-4 text-right" style="display: flex; flex-direction: row; align-items: baseline; justify-content: space-evenly;">
             <%= link_to t('.edit_btn'), edit_admin_registrar_api_user_path(@api_user.registrar,
                                                                            @api_user),
                         class: 'btn btn-primary' %>
@@ -20,6 +20,16 @@
                         method: :delete,
                         data: { confirm: t('.delete_btn_confirm') },
                         class: 'btn btn-default' %>
+
+            <% if !@api_user.accredited? || @api_user.accreditation_expired? %>
+                <%= button_to t(:set_test_btn),
+                              { controller: 'api_users', action: 'set_test_date_to_api_user', user_api_id: @api_user.id },
+                              { method: :post, class: 'btn btn-primary'} %>
+            <% else %>
+                <%= button_to t(:remove_test_btn),
+                              { controller: 'api_users', action: 'remove_test_date_to_api_user', user_api_id: @api_user.id },
+                              { method: :post, class: 'btn btn-danger'} %>
+            <% end %>
         </div>
     </div>
 </div>

--- a/app/views/admin/registrars/index.html.erb
+++ b/app/views/admin/registrars/index.html.erb
@@ -33,6 +33,10 @@
                     <th class="col-xs-4">
                         <%= t(:emails) %>
                     </th>
+                    </th>
+                    <th>
+                        Test status
+                    </th>
                 </tr>
                 </thead>
                 <tbody>
@@ -56,6 +60,17 @@
                             <%= content_tag(:span, x.email) %>
                             <% if x[:billing_email].present? %>
                                 <%= content_tag(:span, x[:billing_email]) %>
+                            <% end %>
+                        </td>
+                        <td>
+                            <% if !x.accredited? || x.accreditation_expired? %>
+                                <%= button_to t('.set_test_btn'),
+                                              { controller: 'registrars', action: 'set_test_date', registrar_id: x.id},
+                                              { method: :post, class: 'btn btn-primary'} %>
+                            <% else %>
+                                <%= button_to t('.remove_test_btn'),
+                                              { controller: 'registrars', action: 'remove_test_date', registrar_id: x.id},
+                                              { method: :post, class: 'btn btn-danger'} %>
                             <% end %>
                         </td>
                     </tr>

--- a/app/views/admin/registrars/show/_api_users.html.erb
+++ b/app/views/admin/registrars/show/_api_users.html.erb
@@ -8,6 +8,7 @@
             <tr>
                 <th class="col-xs-6"><%= ApiUser.human_attribute_name :username %></th>
                 <th class="col-xs-6"><%= ApiUser.human_attribute_name :active %></th>
+                <th class="col-xs-6">Test Results</th>
             </tr>
         </thead>
 
@@ -16,6 +17,18 @@
                 <tr>
                     <td><%= link_to api_user, admin_registrar_api_user_path(api_user.registrar, api_user) %></td>
                     <td><%= api_user.active %></td>
+                    <td>
+
+                        <% if !api_user.accredited? || api_user.accreditation_expired? %>
+                            <%= button_to t('.set_test_btn'),
+                                          { controller: 'api_users', action: 'set_test_date_to_api_user', user_api_id: api_user.id },
+                                          { method: :post, class: 'btn btn-primary'} %>
+                        <% else %>
+                            <%= button_to t('.remove_test_btn'),
+                                          { controller: 'api_users', action: 'remove_test_date_to_api_user', user_api_id: api_user.id },
+                                          { method: :post, class: 'btn btn-danger'} %>
+                        <% end %>
+                    </td>
                 </tr>
             <% end %>
         </tbody>

--- a/config/application.yml.sample
+++ b/config/application.yml.sample
@@ -242,4 +242,3 @@ billing_system_integrated: 'true'
 secret_access_word: 'please-Give-Me-accesS'
 secret_word: 'this-secret-should-be-change'
 allow_accr_endspoints: 'true'
-

--- a/config/locales/admin/api_users.en.yml
+++ b/config/locales/admin/api_users.en.yml
@@ -3,6 +3,8 @@ en:
     api_users:
       index:
         header: API users
+        set_test_btn: Set Test
+        remove_test_btn: Remove Test
 
       new:
         header: New API user

--- a/config/locales/admin/registrars.en.yml
+++ b/config/locales/admin/registrars.en.yml
@@ -4,6 +4,8 @@ en:
       index:
         header: Registrars
         new_btn: New registrar
+        set_test_btn: Set Test
+        remove_test_btn: Remove Test
 
       new:
         header: New registrar
@@ -28,6 +30,8 @@ en:
         api_users:
           header: API Users
           new_btn: New API user
+          set_test_btn: Set Test
+          remove_test_btn: Remove Test
 
         white_ips:
           header: Whitelisted IPs

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -635,6 +635,8 @@ en:
   registrant_ident: 'Registrant ident'
   contact_ident: 'Contact ident'
   results_per_page: 'Results per page'
+  set_test_btn: Set Test
+  remove_test_btn: Remove Test
   nameserver_hostname: 'Nameserver hostname'
   result_count:
     zero: 'No results'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -176,10 +176,13 @@ Rails.application.routes.draw do
       namespace :accreditation_center do
         # At the moment invoice_status endpoint returns only cancelled invoices. But in future logic of this enpoint can change.
         # And it will need to return invoices of different statuses. I decided to leave the name of the endpoint "invoice_status"
-        resources :invoice_status, only: [:index]
-        resource :domains, only: [:show], param: :name
-        resource :contacts, only: [:show], param: :id
+        resources :invoice_status, only: [ :index ]
+        resource :domains, only: [ :show ], param: :name
+        resource :contacts, only: [ :show ], param: :id
+        resource :results, only: [ :show ], param: :name
         # resource :auth, only: [ :index ]
+        get 'show_api_user', to: 'results#show_api_user'
+        get 'list_accreditated_api_users', to: 'results#list_accreditated_api_users'
         get 'auth', to: 'auth#index'
       end
 
@@ -393,6 +396,13 @@ Rails.application.routes.draw do
     resources :registrars do
       resources :api_users, except: %i[index]
       resources :white_ips
+
+      collection do
+        post 'set_test_date', to: 'registrars#set_test_date', as: 'set_test_date'
+        post 'remove_test_date', to: 'registrars#remove_test_date', as: 'remove_test_date'
+        post 'set_test_date_to_api_user', to: 'api_users#set_test_date_to_api_user', as: 'set_test_date_to_api_user'
+        post 'remove_test_date_to_api_user', to: 'api_users#remove_test_date_to_api_user', as: 'remove_test_date_to_api_user'
+      end
     end
 
     resources :contacts do

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5416,5 +5416,3 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220504090512'),
 ('20220524130709'),
 ('20220818075833');
-
-

--- a/test/integration/admin_area/api_users_test.rb
+++ b/test/integration/admin_area/api_users_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class AdminAreaRegistrarsIntegrationTest < ActionDispatch::IntegrationTest
+    include Devise::Test::IntegrationHelpers
+  
+    setup do
+      @api_user = users(:api_bestnames)
+      sign_in users(:admin)
+    end
+  
+    def test_set_test_date_to_api_user
+      date = Time.zone.now - 10.minutes
+  
+      api_user = @api_user.dup
+      api_user.accreditation_date = date
+      api_user.accreditation_expire_date = api_user.accreditation_date + 1.year
+      api_user.save
+  
+      assert_nil @api_user.accreditation_date
+      assert_equal api_user.accreditation_date, date
+  
+      # api_v1_accreditation_center_show_api_user_url
+      stub_request(:get, "http://registry.test:3000/api/v1/accreditation_center/show_api_user?identity_code=#{@api_user.identity_code}&username=#{@api_user.username}").
+        with(
+          headers: {
+          'Accept'=>'*/*',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'User-Agent'=>'Ruby'
+          }).to_return(status: 200, body: { code: 200, user_api: api_user }.to_json, headers: {})
+
+  
+      post set_test_date_to_api_user_admin_registrars_path, params: { user_api_id: @api_user.id }, headers: { "HTTP_REFERER" => root_path }
+      @api_user.reload
+  
+      assert_equal @api_user.accreditation_date.to_date,  api_user.accreditation_date.to_date
+      assert_equal @api_user.accreditation_expire_date.to_date,  api_user.accreditation_expire_date.to_date
+    end
+  end

--- a/test/integration/admin_area/api_users_test.rb
+++ b/test/integration/admin_area/api_users_test.rb
@@ -4,6 +4,8 @@ class AdminAreaRegistrarsIntegrationTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
   setup do
+    ENV['registry_demo_registrar_api_user_url'] = 'http://registry.test:3000/api/v1/accreditation_center/show_api_user'
+    ENV['registry_demo_registrar_port'] = '3000'
     @api_user = users(:api_bestnames)
     sign_in users(:admin)
   end
@@ -22,14 +24,16 @@ class AdminAreaRegistrarsIntegrationTest < ActionDispatch::IntegrationTest
     assert_equal api_user.accreditation_date, date
 
     # api_v1_accreditation_center_show_api_user_url
-    stub_request(:get, "http://registry.test:3000/api/v1/accreditation_center/show_api_user?identity_code=#{@api_user.identity_code}&username=#{@api_user.username}").
-      with(
+    stub_request(:get, "http://registry.test:3000/api/v1/accreditation_center/show_api_user?username=#{@api_user.username}&identity_code=#{@api_user.identity_code}")
+      .with(
         headers: {
-        'Accept'=>'*/*',
-        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-        'User-Agent'=>'Ruby'
-        }).to_return(status: 200, body: { code: 200, user_api: api_user }.to_json, headers: {})
-    post set_test_date_to_api_user_admin_registrars_path, params: { user_api_id: @api_user.id }, headers: { "HTTP_REFERER" => root_path }
+          'Accept' => '*/*',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'User-Agent' => 'Ruby'
+        }
+      )
+      .to_return(status: 200, body: { code: 200, user_api: api_user }.to_json, headers: {})
+    post set_test_date_to_api_user_admin_registrars_path, params: { user_api_id: @api_user.id }, headers: { 'HTTP_REFERER' => root_path }
     @api_user.reload
     assert_equal @api_user.accreditation_date.to_date, api_user.accreditation_date.to_date
     assert_equal @api_user.accreditation_expire_date.to_date, api_user.accreditation_expire_date.to_date

--- a/test/integration/admin_area/api_users_test.rb
+++ b/test/integration/admin_area/api_users_test.rb
@@ -1,38 +1,37 @@
 require 'test_helper'
 
 class AdminAreaRegistrarsIntegrationTest < ActionDispatch::IntegrationTest
-    include Devise::Test::IntegrationHelpers
-  
-    setup do
-      @api_user = users(:api_bestnames)
-      sign_in users(:admin)
-    end
-  
-    def test_set_test_date_to_api_user
-      date = Time.zone.now - 10.minutes
-  
-      api_user = @api_user.dup
-      api_user.accreditation_date = date
-      api_user.accreditation_expire_date = api_user.accreditation_date + 1.year
-      api_user.save
-  
-      assert_nil @api_user.accreditation_date
-      assert_equal api_user.accreditation_date, date
-  
-      # api_v1_accreditation_center_show_api_user_url
-      stub_request(:get, "http://registry.test:3000/api/v1/accreditation_center/show_api_user?identity_code=#{@api_user.identity_code}&username=#{@api_user.username}").
-        with(
-          headers: {
-          'Accept'=>'*/*',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'User-Agent'=>'Ruby'
-          }).to_return(status: 200, body: { code: 200, user_api: api_user }.to_json, headers: {})
+  include Devise::Test::IntegrationHelpers
 
-  
-      post set_test_date_to_api_user_admin_registrars_path, params: { user_api_id: @api_user.id }, headers: { "HTTP_REFERER" => root_path }
-      @api_user.reload
-  
-      assert_equal @api_user.accreditation_date.to_date,  api_user.accreditation_date.to_date
-      assert_equal @api_user.accreditation_expire_date.to_date,  api_user.accreditation_expire_date.to_date
-    end
+  setup do
+    @api_user = users(:api_bestnames)
+    sign_in users(:admin)
   end
+
+  def test_set_test_date_to_api_user
+    # ENV['registry_demo_registrar_api_user_url'] = 'http://testapi.test'
+
+    date = Time.zone.now - 10.minutes
+
+    api_user = @api_user.dup
+    api_user.accreditation_date = date
+    api_user.accreditation_expire_date = api_user.accreditation_date + 1.year
+    api_user.save
+
+    assert_nil @api_user.accreditation_date
+    assert_equal api_user.accreditation_date, date
+
+    # api_v1_accreditation_center_show_api_user_url
+    stub_request(:get, "http://registry.test:3000/api/v1/accreditation_center/show_api_user?identity_code=#{@api_user.identity_code}&username=#{@api_user.username}").
+      with(
+        headers: {
+        'Accept'=>'*/*',
+        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'User-Agent'=>'Ruby'
+        }).to_return(status: 200, body: { code: 200, user_api: api_user }.to_json, headers: {})
+    post set_test_date_to_api_user_admin_registrars_path, params: { user_api_id: @api_user.id }, headers: { "HTTP_REFERER" => root_path }
+    @api_user.reload
+    assert_equal @api_user.accreditation_date.to_date, api_user.accreditation_date.to_date
+    assert_equal @api_user.accreditation_expire_date.to_date, api_user.accreditation_expire_date.to_date
+  end
+end

--- a/test/integration/admin_area/registrars_test.rb
+++ b/test/integration/admin_area/registrars_test.rb
@@ -4,6 +4,8 @@ class AdminAreaRegistrarsIntegrationTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
   setup do
+    ENV['registry_demo_registrar_results_url'] = 'http://registry.test:3000/api/v1/accreditation_center/results'
+    ENV['registry_demo_registrar_port'] = '3000'
     @registrar = registrars(:bestnames)
     sign_in users(:admin)
   end
@@ -26,18 +28,20 @@ class AdminAreaRegistrarsIntegrationTest < ActionDispatch::IntegrationTest
 
     assert_nil @registrar.api_users.first.accreditation_date
 
-    stub_request(:get, "http://registry.test:3000/api/v1/accreditation_center/results?registrar_name=#{@registrar.name}").
-    with(
-      headers: {
-      'Accept'=>'*/*',
-      'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-      'User-Agent'=>'Ruby'
-      }).to_return(status: 200, body: { code: 200, registrar_users: [api_user] }.to_json, headers: {})
+    stub_request(:get, "http://registry.test:3000/api/v1/accreditation_center/results?registrar_name=#{@registrar.name}")
+      .with(
+        headers: {
+          'Accept' => '*/*',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'User-Agent' => 'Ruby'
+        }
+      )
+      .to_return(status: 200, body: { code: 200, registrar_users: [api_user] }.to_json, headers: {})
 
-    post set_test_date_admin_registrars_path, params: { registrar_id: @registrar.id }, headers: { "HTTP_REFERER" => root_path }
+    post set_test_date_admin_registrars_path, params: { registrar_id: @registrar.id }, headers: { 'HTTP_REFERER' => root_path }
     @registrar.reload
 
-    assert_equal @registrar.api_users.first.accreditation_date.to_date,  api_user.accreditation_date.to_date
-    assert_equal @registrar.api_users.first.accreditation_expire_date.to_date,  api_user.accreditation_expire_date.to_date
+    assert_equal @registrar.api_users.first.accreditation_date.to_date, api_user.accreditation_date.to_date
+    assert_equal @registrar.api_users.first.accreditation_expire_date.to_date, api_user.accreditation_expire_date.to_date
   end
 end

--- a/test/integration/admin_area/registrars_test.rb
+++ b/test/integration/admin_area/registrars_test.rb
@@ -17,4 +17,27 @@ class AdminAreaRegistrarsIntegrationTest < ActionDispatch::IntegrationTest
 
     assert_equal new_iban, @registrar.iban
   end
+
+  def test_set_test_date
+    api_user = @registrar.api_users.first.dup
+    api_user.accreditation_date = Time.zone.now - 10.minutes
+    api_user.accreditation_expire_date = api_user.accreditation_date + 1.year
+    api_user.save
+
+    assert_nil @registrar.api_users.first.accreditation_date
+
+    stub_request(:get, "http://registry.test:3000/api/v1/accreditation_center/results?registrar_name=#{@registrar.name}").
+    with(
+      headers: {
+      'Accept'=>'*/*',
+      'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+      'User-Agent'=>'Ruby'
+      }).to_return(status: 200, body: { code: 200, registrar_users: [api_user] }.to_json, headers: {})
+
+    post set_test_date_admin_registrars_path, params: { registrar_id: @registrar.id }, headers: { "HTTP_REFERER" => root_path }
+    @registrar.reload
+
+    assert_equal @registrar.api_users.first.accreditation_date.to_date,  api_user.accreditation_date.to_date
+    assert_equal @registrar.api_users.first.accreditation_expire_date.to_date,  api_user.accreditation_expire_date.to_date
+  end
 end

--- a/test/interactions/record_date_of_test_test.rb
+++ b/test/interactions/record_date_of_test_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class RecordDateOfTestTest < ActiveSupport::TestCase
+  setup do
+    @api_bestname = users(:api_bestnames)
+    @api_bestname.accreditation_date = Time.zone.now - 10.minutes
+    @api_bestname.accreditation_expire_date = @api_bestname.accreditation_date + 1.year
+    @api_bestname.save
+  end
+
+  def test_should_record_data_to_apiuser
+    api_goodname = users(:api_goodnames)
+
+    assert_nil api_goodname.accreditation_date
+    assert_nil api_goodname.accreditation_expire_date
+
+    Actions::RecordDateOfTest.record_result_to_api_user(api_user: api_goodname, date: @api_bestname.accreditation_date)
+
+    assert_equal api_goodname.accreditation_date, @api_bestname.accreditation_date
+    assert_equal api_goodname.accreditation_expire_date, @api_bestname.accreditation_expire_date
+  end
+end

--- a/test/system/admin_area/api_users_test.rb
+++ b/test/system/admin_area/api_users_test.rb
@@ -3,6 +3,7 @@ require 'application_system_test_case'
 class AdminApiUsersSystemTest < ApplicationSystemTestCase
   setup do
     sign_in users(:admin)
+    @registrar = registrars(:bestnames)
   end
 
   def test_shows_api_user_list
@@ -10,5 +11,72 @@ class AdminApiUsersSystemTest < ApplicationSystemTestCase
 
     api_user = users(:api_bestnames)
     assert_link api_user.username, href: admin_registrar_api_user_path(api_user.registrar, api_user)
+  end
+
+  def test_should_display_tests_button_in_api_user
+    visit admin_api_users_path
+
+    assert_button 'Set Test'
+    assert_no_button 'Remove Test'
+  end
+
+  def test_should_display_remove_test_if_there_accreditated_apiuser
+    date = Time.zone.now - 10.minutes
+
+    api_user = @registrar.api_users.first
+    api_user.accreditation_date = date
+    api_user.accreditation_expire_date = api_user.accreditation_date + 1.year
+    api_user.save
+
+    visit admin_api_users_path
+
+    assert_button 'Remove Test'
+  end
+
+  def test_should_not_display_remove_test_if_api_user_accreditation_date_is_expired
+    date = Time.zone.now - 1.year - 10.minutes
+
+    api_user = @registrar.api_users.first
+    api_user.accreditation_date = date
+    api_user.accreditation_expire_date = api_user.accreditation_date + 1.year
+    api_user.save
+
+    visit admin_api_users_path
+
+    assert_no_button 'Remove'
+  end
+
+  def test_should_display_tests_button_in_api_user_details
+    api_user = @registrar.api_users.first
+
+    visit admin_api_user_path(api_user)
+    assert_button 'Set Test'
+    assert_no_button 'Remove Test'
+  end
+
+  def test_should_display_remove_test_in_api_user_details_if_there_accreditated_apiuser
+    date = Time.zone.now - 10.minutes
+
+    api_user = @registrar.api_users.first
+    api_user.accreditation_date = date
+    api_user.accreditation_expire_date = api_user.accreditation_date + 1.year
+    api_user.save
+
+    visit admin_api_user_path(api_user)
+
+    assert_button 'Remove Test'
+  end
+
+  def test_should_not_display_remove_test_if_api_user_accreditation_date_is_expired_in_api_details
+    date = Time.zone.now - 1.year - 10.minutes
+
+    api_user = @registrar.api_users.first
+    api_user.accreditation_date = date
+    api_user.accreditation_expire_date = api_user.accreditation_date + 1.year
+    api_user.save
+
+    visit admin_api_user_path(api_user)
+
+    assert_no_button 'Remove'
   end
 end

--- a/test/system/admin_area/registrars_test.rb
+++ b/test/system/admin_area/registrars_test.rb
@@ -93,4 +93,70 @@ class AdminRegistrarsSystemTest < ApplicationSystemTestCase
     assert_text 'Language English'
     assert_text 'billing@bestnames.test'
   end
+
+  def test_should_display_btn_for_set_test_date
+    visit admin_registrars_path
+
+    assert_button 'Set Test'
+    assert_no_button 'Remove Test'
+  end
+
+  def test_should_display_remove_test_if_there_accreditated_registrars
+    date = Time.zone.now - 10.minutes
+
+    api_user = @registrar.api_users.first
+    api_user.accreditation_date = date
+    api_user.accreditation_expire_date = api_user.accreditation_date + 1.year
+    api_user.save
+
+    visit admin_registrars_path
+
+    assert_button 'Remove Test'
+  end
+
+  def test_should_not_display_remove_test_if_accreditation_date_is_expired
+    date = Time.zone.now - 1.year - 10.minutes
+
+    api_user = @registrar.api_users.first
+    api_user.accreditation_date = date
+    api_user.accreditation_expire_date = api_user.accreditation_date + 1.year
+    api_user.save
+
+    visit admin_registrars_path
+
+    assert_no_button 'Remove'
+  end
+
+  def test_should_display_tests_button_in_registrar_deftails
+    visit admin_registrar_path(@registrar)
+
+    assert_button 'Set Test'
+    assert_no_button 'Remove Test'
+  end
+
+  def test_should_display_remove_test_if_there_accreditated_registrars_in_registrar_details
+    date = Time.zone.now - 10.minutes
+
+    api_user = @registrar.api_users.first
+    api_user.accreditation_date = date
+    api_user.accreditation_expire_date = api_user.accreditation_date + 1.year
+    api_user.save
+
+    visit admin_registrar_path(@registrar)
+
+    assert_button 'Remove Test'
+  end
+
+  def test_should_not_display_remove_test_if_accreditation_date_is_expired_in_registrar_details
+    date = Time.zone.now - 1.year - 10.minutes
+
+    api_user = @registrar.api_users.first
+    api_user.accreditation_date = date
+    api_user.accreditation_expire_date = api_user.accreditation_date + 1.year
+    api_user.save
+
+    visit admin_registrar_path(@registrar)
+
+    assert_no_button 'Remove'
+  end
 end


### PR DESCRIPTION
Related to https://github.com/internetee/accreditation_center/issues/131

In these files add env conditions:
```
repp/v1/registrar/accreditation_results_controller.rb
repp/v1/registrar/accreditation_info_controller.rb
api/v1/accreditation_center/base_controller.rb
```

~~Rails.env.development? || Rails.env.staging? || Rails.env.test?~~
~~When will added new env demo, then this env conditions need to change to Rails.env.demo?~~

Added a new condition for displaying an endpoint in an isolated environment. To do this, you need to add the key in application.yml `allow_accr_endspoints: 'true'` for the test registry environment. Then endpoints for working with registry production will be available. For other environments, for example, for staging and production, this key can be omitted.

in application.yml need to add these keys:
```
registry_demo_registrar_port: '3000'
registry_demo_registrar_results_url: 'http://registry.test/api/v1/accreditation_center/results'
registry_demo_registrar_api_user_url: 'http://registry.test/api/v1/accreditation_center/show_api_user'
registry_demo_accredited_users_url: 'http://registry.test/api/v1/accreditation_center/list_accreditated_api_users'
```

These links below are endpoints
instead `http://registry.test/` should base url of demo env registry

Job, which check all user api in demo env database called by `SyncAccreditedUsersJob.perform_now`