### PR TITLE
Updated sidekiq gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ gem 'jquery-ui-rails', '6.0.1'
 gem 'pdfkit'
 gem 'que'
 gem 'que-web'
-gem 'sidekiq'
+gem 'sidekiq', '>= 6.4.1'
 
 gem 'company_register', github: 'internetee/company_register',
                         branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -449,7 +449,7 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sidekiq (6.4.0)
+    sidekiq (6.4.1)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
@@ -588,7 +588,7 @@ DEPENDENCIES
   sass-rails
   select2-rails (= 4.0.13)
   selectize-rails (= 0.12.6)
-  sidekiq
+  sidekiq (>= 6.4.1)
   simplecov (= 0.17.1)
   simpleidn (= 0.2.1)
   spy
@@ -601,4 +601,4 @@ DEPENDENCIES
   wkhtmltopdf-binary (~> 0.12.5.1)
 
 BUNDLED WITH
-   2.2.31
+   2.3.9


### PR DESCRIPTION
Constant Warning: Redis Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.
This was fixed in the newer versions of Sidekiq.
Upgraded sidekiq version to 6.4.1