### PR TITLE
update docker files 24-04-2022

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,223 @@
+.git
+.gitignore
+
+# Created by https://www.gitignore.io/api/git,ruby,rails,jetbrains+all
+# Edit at https://www.gitignore.io/?templates=git,ruby,rails,jetbrains+all
+
+### Git ###
+# Created by git for backups. To disable backups in Git:
+# $ git config --global mergetool.keepBackup false
+*.orig
+
+# Created by git when using merge tools for conflicts
+*.BACKUP.*
+*.BASE.*
+*.LOCAL.*
+*.REMOTE.*
+*_BACKUP_*.txt
+*_BASE_*.txt
+*_LOCAL_*.txt
+*_REMOTE_*.txt
+
+### JetBrains+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### JetBrains+all Patch ###
+# Ignores the whole .idea folder and all .iml files
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+
+.idea/
+
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
+### Rails ###
+*.rbc
+capybara-*.html
+.rspec
+/db/*.sqlite3
+/db/*.sqlite3-journal
+/public/system
+/coverage/
+/spec/tmp
+rerun.txt
+pickle-email-*.html
+
+# Ignore all logfiles and tempfiles.
+/log/*
+/tmp/*
+!/log/.keep
+!/tmp/.keep
+
+# TODO Comment out this rule if you are OK with secrets being uploaded to the repo
+config/initializers/secret_token.rb
+config/master.key
+
+# Only include if you have production secrets in this file, which is no longer a Rails default
+# config/secrets.yml
+
+# dotenv
+# TODO Comment out this rule if environment variables can be committed
+.env
+
+## Environment normalization:
+/.bundle
+/vendor/bundle
+
+# these should all be checked in to normalize the environment:
+# Gemfile.lock, .ruby-version, .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+# if using bower-rails ignore default bower_components path bower.json files
+/vendor/assets/bower_components
+*.bowerrc
+bower.json
+
+# Ignore pow environment settings
+.powenv
+
+# Ignore Byebug command history file.
+.byebug_history
+
+# Ignore node_modules
+node_modules/
+
+# Ignore precompiled javascript packs
+/public/packs
+/public/packs-test
+/public/assets
+
+# Ignore yarn files
+/yarn-error.log
+yarn-debug.log*
+.yarn-integrity
+
+# Ignore uploaded files in development
+/storage/*
+!/storage/.keep
+
+### Ruby ###
+*.gem
+/.config
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Used by dotenv library to load environment variables.
+# .env
+
+# Ignore Byebug command history file.
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# vendor/Pods/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+/.bundle/
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+
+# End of https://www.gitignore.io/api/git,ruby,rails,jetbrains+all

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /config/application.yml
 /config/environments/development.rb
 /config/deploy.rb
+/config/master.key
 /.idea
 
 # Do not commit one. Instead, download the latest from https://github.com/internetee/style-guide.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,30 @@
-FROM internetee/ruby:3.0-buster
+FROM ruby:3.0.3-alpine
 
+RUN apk update && apk upgrade
+RUN apk add --update --no-cache \
+  build-base \
+  curl \
+  git \
+  gnupg1 \
+  libffi-dev \
+  libsodium-dev \
+  libxml2 \
+  libxml2-dev \
+  shared-mime-info \
+  postgresql-dev \
+  tzdata \
+  yarn && rm -rf /var/cache/apk/*
+
+ENV APP_HOME /opt/webapps/app
+WORKDIR $APP_HOME
+
+COPY Gemfile* $APP_HOME/
+RUN gem install bundler && bundle install
+
+COPY . $APP_HOME
+
+RUN rm -rf $APP_HOME/tmp/*
 RUN mkdir -p /opt/webapps/app/tmp/pids
-WORKDIR /opt/webapps/app
-COPY Gemfile Gemfile.lock ./
-RUN gem install bundler && bundle install --jobs 20 --retry 5
-
 EXPOSE 3000
+CMD bundle exec rails db:migrate \
+  && bundle exec rails s -b 0.0.0.0

--- a/Dockerfile.old
+++ b/Dockerfile.old
@@ -1,0 +1,8 @@
+FROM internetee/ruby:3.0-buster
+
+RUN mkdir -p /opt/webapps/app/tmp/pids
+WORKDIR /opt/webapps/app
+COPY Gemfile Gemfile.lock ./
+RUN gem install bundler && bundle install --jobs 20 --retry 5
+
+EXPOSE 3000


### PR DESCRIPTION
~~This is just a test. I am not sure that it works as expected, because some problems with smtp connection. I need figure it out, if it the dockerfile reason or not.~~ Any way, this docker image reduced the size of image from  2.77GB to 1.62GB!

UPDATED: I remove couple based images like ruby-slim-buster and ruby-alpline, remove registry image and rebuild again and problem with smtp is gone. So, seems everything works as expected

1. Notes: this is dockerfile only for development environment. For Kubernetes staging and production use another instances
2. Notes: this dockerfile use alpine linux distribute, so it doesn't contain bash terminal. So, to run this docker file in docker-compose.yml need to change `command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails server -b 0.0.0.0"` to `command: sh -c "rm -f tmp/pids/server.pid && bundle exec rails server -b 0.0.0.0"` in registry section and the same for epp section. 