### PR TITLE
Modified verify email rake task

### DIFF
--- a/lib/tasks/verify_email.rake
+++ b/lib/tasks/verify_email.rake
@@ -3,6 +3,7 @@ require 'rake_option_parser_boilerplate'
 require 'syslog/logger'
 require 'active_record'
 
+# rubocop:disable Metrics/BlockLength
 namespace :verify_email do
   # bundle exec rake verify_email:check_all -- --domain_name=shop.test --check_level=mx
   #  --spam_protect=true --batch_size=1000 --limit=100
@@ -36,6 +37,7 @@ namespace :verify_email do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength
 
 def check_level(options)
   options[:check_level]


### PR DESCRIPTION
Related to #2364

Modified verify email rake task so the contacts batch size and limit can be added as options: 
`bundle exec rake verify_email:check_all -- --batch_size=1000 --limit=100`
or
`bundle exec rake verify_email:check_all -- -b1000 -l100`

By default batch_size is 10000 and limit is 0 (0 = unlimited).

NB! Changing batch_size will not stop the task from finding all the contacts, which need email validation. VerifyEmailsJob will start for each contact. Adjusting limit option will limit the amount of contacts that need to be validated, thus helping to protect from overloading by sidekiq jobs and to troubleshoot task problems in production environment.
