### PR TITLE
assign auction type for nil value rake task

### DIFF
--- a/lib/tasks/assing_auction_platform_type.rake
+++ b/lib/tasks/assing_auction_platform_type.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+namespace :auction do
+  desc 'Check closed disputes with expired_at in the Past'
+  task assign_platform_type: :environment do
+    auctions = Auction.where(platform: nil)
+
+    auctions.each do |auction|
+      auction.update(platform: :auto)
+    end
+  end
+end

--- a/test/tasks/assign_auction_platform_type_test.rb
+++ b/test/tasks/assign_auction_platform_type_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class AssignAuctionPlatformTypeTest < ActiveSupport::TestCase
+  setup do
+    @auction_one = auctions(:one)
+    @auction_two = auctions(:idn)
+  end
+
+  def test_output
+    assert_nil @auction_one.platform
+    assert_nil @auction_two.platform
+
+    run_task
+
+    @auction_one.reload
+    @auction_two.reload
+
+    assert_equal @auction_one.platform, "auto"
+    assert_equal @auction_two.platform, "auto"
+  end
+
+  private
+
+  def run_task
+    Rake::Task['auction:assign_platform_type'].execute
+  end
+end


### PR DESCRIPTION
This task will iterate through all the auctions in the registry that have platform nil values. And for these auctions, assign the value type as "auto". It is advisable to run this job before the production of the English auction.