### PR TITLE
outzone rake task for invalid email domains

### DIFF
--- a/app/controllers/eis_billing/e_invoice_response_controller.rb
+++ b/app/controllers/eis_billing/e_invoice_response_controller.rb
@@ -10,6 +10,8 @@ class EisBilling::EInvoiceResponseController < EisBilling::BaseController
 
   def mark_e_invoice_sent_at(invoice_number)
     invoice = Invoice.find_by(number: invoice_number)
+    invoice = Invoice.find_by(number: invoice_number['invoice_number']) if invoice.nil?
+
     invoice.update(e_invoice_sent_at: Time.zone.now)
   end
 end

--- a/app/interactions/domains/force_delete/set_status.rb
+++ b/app/interactions/domains/force_delete/set_status.rb
@@ -16,7 +16,7 @@ module Domains
 
       def force_delete_soft
         years = (domain.valid_to.to_date - Time.zone.today).to_i / 365
-        soft_forcedelete_dates(years) if years.positive?
+        years.positive? ? soft_forcedelete_dates(years) : set_less_than_year_until_valid_to_date
       end
 
       private
@@ -24,12 +24,19 @@ module Domains
       def soft_forcedelete_dates(years)
         domain.force_delete_start = domain.valid_to - years.years
         domain.force_delete_date = domain.force_delete_start +
-                                   Setting.expire_warning_period.days +
-                                   Setting.redemption_grace_period.days
+                                   expire_warning_period_days +
+                                   redemption_grace_period_days
+      end
+
+      def set_less_than_year_until_valid_to_date
+        domain.force_delete_start = domain.valid_to
+        domain.force_delete_date = domain.force_delete_start +
+                                   expire_warning_period_days +
+                                   redemption_grace_period_days
       end
 
       def redemption_grace_period_days
-        Setting.redemption_grace_period.days + 1.day
+        Setting.redemption_grace_period.days
       end
 
       def expire_warning_period_days

--- a/app/interactions/domains/force_delete/set_status.rb
+++ b/app/interactions/domains/force_delete/set_status.rb
@@ -16,7 +16,7 @@ module Domains
 
       def force_delete_soft
         years = (domain.valid_to.to_date - Time.zone.today).to_i / 365
-        years.positive? ? soft_forcedelete_dates(years) : set_less_than_year_until_valid_to_date
+        soft_forcedelete_dates(years) if years.positive?
       end
 
       private
@@ -24,19 +24,12 @@ module Domains
       def soft_forcedelete_dates(years)
         domain.force_delete_start = domain.valid_to - years.years
         domain.force_delete_date = domain.force_delete_start +
-                                   expire_warning_period_days +
-                                   redemption_grace_period_days
-      end
-
-      def set_less_than_year_until_valid_to_date
-        domain.force_delete_start = domain.valid_to
-        domain.force_delete_date = domain.force_delete_start +
-                                   expire_warning_period_days +
-                                   redemption_grace_period_days
+                                   Setting.expire_warning_period.days +
+                                   Setting.redemption_grace_period.days
       end
 
       def redemption_grace_period_days
-        Setting.redemption_grace_period.days
+        Setting.redemption_grace_period.days + 1.day
       end
 
       def expire_warning_period_days

--- a/app/jobs/outzone_invalid_email_domains_job.rb
+++ b/app/jobs/outzone_invalid_email_domains_job.rb
@@ -3,7 +3,6 @@ class OutzoneInvalidEmailDomainsJob < ApplicationJob
 
   def perform
     domains = Domain.where("force_delete_data->'template_name' = ?", 'invalid_email')
-                    .where("force_delete_data->'force_delete_type' = ?", 'soft')
                     .where(outzone_at: nil)
                     .where('Date(force_delete_start) <= ?', Time.zone.now)
 

--- a/app/jobs/outzone_invalid_email_domains_job.rb
+++ b/app/jobs/outzone_invalid_email_domains_job.rb
@@ -1,0 +1,22 @@
+class OutzoneInvalidEmailDomainsJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    domains = Domain.where("force_delete_data->'template_name' = ?", 'invalid_email')
+                    .where("force_delete_data->'force_delete_type' = ?", 'soft')
+                    .where(outzone_at: nil)
+                    .where('Date(force_delete_start) <= ?', Time.zone.now)
+
+    domains.each do |domain|
+      outzone(domain)
+    end
+  end
+
+  private
+
+  def outzone(domain)
+    domain.outzone_at = domain.force_delete_start + Domain.expire_warning_period
+    domain.delete_date = domain.outzone_at + Domain.redemption_grace_period
+    domain.save
+  end
+end

--- a/lib/tasks/outzone_invalid_email_domains.rake
+++ b/lib/tasks/outzone_invalid_email_domains.rake
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+desc 'Rake task run outzone setter task for force deleted domains by invalid emails'
+
+task outzone_invalid_email_domains: :environment do
+  OutzoneInvalidEmailDomainsJob.perform_later
+end

--- a/test/interactions/force_delete_email/base_test.rb
+++ b/test/interactions/force_delete_email/base_test.rb
@@ -20,25 +20,6 @@ class BaseTest < ActiveSupport::TestCase
     assert_not @domain.force_delete_scheduled?
   end
 
-  def test_less_than_year_until_valid_to_date
-    refute @domain_airport.force_delete_scheduled?
-    @domain_airport.update!(valid_to: Time.zone.now + 11.months)
-    @domain_airport.reload
-    prepare_contact
-
-    contact = @domain_airport.admin_contacts.first
-
-    Domains::ForceDeleteEmail::Base.run(email: contact.email)
-    @domain_airport.reload
-
-    assert @domain_airport.force_delete_scheduled?
-    assert @domain_airport.valid_to < Time.zone.now + 1.year
-    assert_equal @domain_airport.force_delete_start, @domain_airport.valid_to
-    assert_equal @domain_airport.force_delete_date, (@domain_airport.force_delete_start +
-                                                    Setting.expire_warning_period.days +
-                                                    Setting.redemption_grace_period.days).to_date
-  end
-
   def test_more_that_year_until_valid_to_date
     refute @domain_airport.force_delete_scheduled?
     @domain_airport.update!(valid_to: Time.zone.now + 3.years + 1.month + 1.day)

--- a/test/interactions/force_delete_email/base_test.rb
+++ b/test/interactions/force_delete_email/base_test.rb
@@ -1,18 +1,111 @@
 require 'test_helper'
 
 class BaseTest < ActiveSupport::TestCase
-  def test_hold_domains_force_delete_email
-    domain = domains(:shop)
-    domain.update!(statuses: [DomainStatus::SERVER_HOLD])
-    domain.update!(expire_time: Time.zone.now + 1.year)
+  setup do
+    @domain = domains(:shop)
+    @domain_airport = domains(:airport)
+  end
 
-    registrant = domain.registrant
-    registrant.update!(email: "#{registrant.email.split('@').first}@#{domain.name}")
+  def test_hold_domains_force_delete_email
+    @domain.update!(statuses: [DomainStatus::SERVER_HOLD])
+    @domain.update!(expire_time: Time.zone.now + 1.year)
+
+    registrant = @domain.registrant
+    registrant.update!(email: "#{registrant.email.split('@').first}@#{@domain.name}")
 
     Domains::ForceDeleteEmail::Base.run(email: registrant.email)
 
-    domain.reload
+    @domain.reload
 
-    assert_not domain.force_delete_scheduled?
+    assert_not @domain.force_delete_scheduled?
+  end
+
+  def test_less_than_year_until_valid_to_date
+    refute @domain_airport.force_delete_scheduled?
+    @domain_airport.update!(valid_to: Time.zone.now + 11.months)
+    @domain_airport.reload
+    prepare_contact
+
+    contact = @domain_airport.admin_contacts.first
+
+    Domains::ForceDeleteEmail::Base.run(email: contact.email)
+    @domain_airport.reload
+
+    assert @domain_airport.force_delete_scheduled?
+    assert @domain_airport.valid_to < Time.zone.now + 1.year
+    assert_equal @domain_airport.force_delete_start, @domain_airport.valid_to
+    assert_equal @domain_airport.force_delete_date, (@domain_airport.force_delete_start +
+                                                    Setting.expire_warning_period.days +
+                                                    Setting.redemption_grace_period.days).to_date
+  end
+
+  def test_more_that_year_until_valid_to_date
+    refute @domain_airport.force_delete_scheduled?
+    @domain_airport.update!(valid_to: Time.zone.now + 3.years + 1.month + 1.day)
+    @domain_airport.reload
+    prepare_contact
+
+    contact = @domain_airport.admin_contacts.first
+
+    Domains::ForceDeleteEmail::Base.run(email: contact.email)
+    @domain_airport.reload
+
+    assert @domain_airport.force_delete_scheduled?
+    assert @domain_airport.valid_to > Time.zone.now + 1.year
+    assert_equal @domain_airport.force_delete_start.to_date, (Time.zone.now + 1.month + 1.day).to_date
+    assert_equal @domain_airport.force_delete_date, (@domain_airport.force_delete_start +
+                                                    Setting.expire_warning_period.days +
+                                                    Setting.redemption_grace_period.days).to_date
+  end
+
+  def test_more_that_year_until_valid_to_date_but_month_is_previous
+    refute @domain_airport.force_delete_scheduled?
+    @domain_airport.update!(valid_to: Time.zone.now + 3.years - 1.month - 4.days)
+    @domain_airport.reload
+    prepare_contact
+
+    contact = @domain_airport.admin_contacts.first
+
+    Domains::ForceDeleteEmail::Base.run(email: contact.email)
+    @domain_airport.reload
+
+    assert @domain_airport.force_delete_scheduled?
+    assert @domain_airport.valid_to > Time.zone.now + 1.year
+    assert_equal @domain_airport.force_delete_start.to_date, (Time.zone.now + 1.year - 1.month - 4.days).to_date
+    assert_equal @domain_airport.force_delete_date, (@domain_airport.force_delete_start +
+                                                    Setting.expire_warning_period.days +
+                                                    Setting.redemption_grace_period.days).to_date
+  end
+
+  def test_should_send_poll_message_about_45_days_to_registrar
+    refute @domain_airport.force_delete_scheduled?
+    @domain_airport.update!(valid_to: Time.zone.now + 3.years - 1.month - 4.days)
+    @domain_airport.reload
+    prepare_contact
+
+    contact = @domain_airport.admin_contacts.first
+
+    assert_difference -> { @domain_airport.registrar.notifications.count } do
+      Domains::ForceDeleteEmail::Base.run(email: contact.email)
+    end
+
+    @domain_airport.reload
+  end
+
+  private
+
+  def prepare_contact
+    assert_not @domain_airport.force_delete_scheduled?
+    email = '~@internet.ee'
+
+    contact = @domain_airport.admin_contacts.first
+    contact.update_attribute(:email, email)
+    (ValidationEvent::VALID_EVENTS_COUNT_THRESHOLD).times do
+      contact.verify_email
+    end
+    contact.reload
+
+    refute contact.validation_events.last.success?
+    assert contact.need_to_start_force_delete?
   end
 end

--- a/test/jobs/outzone_invalid_email_domains_job_test.rb
+++ b/test/jobs/outzone_invalid_email_domains_job_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class OutzoneInvalidEmailDomainsJobTest < ActiveJob::TestCase
+  include ActionMailer::TestHelper
+
+  setup do
+    ActionMailer::Base.deliveries.clear
+    @domain = domains(:airport)
+  end
+
+  def test_set_outzone_datetime_for_fd_domains_by_invalid_emails
+    assert_nil @domain.outzone_at
+
+    @domain.schedule_force_delete(type: :soft)
+    @domain.force_delete_data = {"template_name"=>"invalid_email", "force_delete_type"=>"soft"}
+    @domain.save
+
+    OutzoneInvalidEmailDomainsJob.perform_now
+    @domain.reload
+
+    assert @domain.force_delete_scheduled?
+    assert @domain.valid_to < Time.zone.now + 1.year
+    assert_equal @domain.force_delete_start, @domain.valid_to
+    assert_equal @domain.force_delete_date, (@domain.force_delete_start +
+                                                    Setting.expire_warning_period.days +
+                                                    Setting.redemption_grace_period.days).to_date
+    assert_equal @domain.outzone_at, @domain.force_delete_start + Setting.expire_warning_period.day
+  end
+
+  private
+
+  def prepare_contact
+    assert_not @domain.force_delete_scheduled?
+    email = '~@internet.ee'
+
+    contact = @domain.admin_contacts.first
+    contact.update_attribute(:email, email)
+    (ValidationEvent::VALID_EVENTS_COUNT_THRESHOLD).times do
+      contact.verify_email
+    end
+    contact.reload
+
+    refute contact.validation_events.last.success?
+    assert contact.need_to_start_force_delete?
+  end
+end

--- a/test/jobs/outzone_invalid_email_domains_job_test.rb
+++ b/test/jobs/outzone_invalid_email_domains_job_test.rb
@@ -20,10 +20,6 @@ class OutzoneInvalidEmailDomainsJobTest < ActiveJob::TestCase
 
     assert @domain.force_delete_scheduled?
     assert @domain.valid_to < Time.zone.now + 1.year
-    assert_equal @domain.force_delete_start, @domain.valid_to
-    assert_equal @domain.force_delete_date, (@domain.force_delete_start +
-                                                    Setting.expire_warning_period.days +
-                                                    Setting.redemption_grace_period.days).to_date
     assert_equal @domain.outzone_at, @domain.force_delete_start + Setting.expire_warning_period.day
   end
 

--- a/test/jobs/outzone_invalid_email_domains_job_test.rb
+++ b/test/jobs/outzone_invalid_email_domains_job_test.rb
@@ -9,6 +9,9 @@ class OutzoneInvalidEmailDomainsJobTest < ActiveJob::TestCase
   end
 
   def test_set_outzone_datetime_for_fd_domains_by_invalid_emails
+    @domain.update(valid_to: Time.zone.now + 3.years)
+    @domain.reload
+
     assert_nil @domain.outzone_at
 
     @domain.schedule_force_delete(type: :soft)
@@ -19,24 +22,7 @@ class OutzoneInvalidEmailDomainsJobTest < ActiveJob::TestCase
     @domain.reload
 
     assert @domain.force_delete_scheduled?
-    assert @domain.valid_to < Time.zone.now + 1.year
+    assert @domain.valid_to > Time.zone.now + 1.year
     assert_equal @domain.outzone_at, @domain.force_delete_start + Setting.expire_warning_period.day
-  end
-
-  private
-
-  def prepare_contact
-    assert_not @domain.force_delete_scheduled?
-    email = '~@internet.ee'
-
-    contact = @domain.admin_contacts.first
-    contact.update_attribute(:email, email)
-    (ValidationEvent::VALID_EVENTS_COUNT_THRESHOLD).times do
-      contact.verify_email
-    end
-    contact.reload
-
-    refute contact.validation_events.last.success?
-    assert contact.need_to_start_force_delete?
   end
 end


### PR DESCRIPTION
Close #2436 

Task can be run like this: `rake outzone_invalid_email_domains`

If this is inconvenient and we want it to be a single FD process flow, it is possible to refactor and add this task in general Domain Cron pipeline