### PR TITLE
Added overwrite feature to SendMonthlyInvoicesJob

### DIFF
--- a/app/jobs/send_monthly_invoices_job.rb
+++ b/app/jobs/send_monthly_invoices_job.rb
@@ -2,8 +2,9 @@ class SendMonthlyInvoicesJob < ApplicationJob # rubocop:disable Metrics/ClassLen
   queue_as :default
   discard_on StandardError
 
-  def perform(dry: false, months_ago: 1)
+  def perform(dry: false, months_ago: 1, overwrite: false)
     @dry = dry
+    @overwrite = overwrite
     @month = Time.zone.now - months_ago.month
     @directo_data = []
 
@@ -48,7 +49,7 @@ class SendMonthlyInvoicesJob < ApplicationJob # rubocop:disable Metrics/ClassLen
 
   def find_or_init_monthly_invoices(invoices: [])
     Registrar.with_cash_accounts.find_each do |registrar|
-      invoice = registrar.find_or_init_monthly_invoice(month: @month)
+      invoice = registrar.find_or_init_monthly_invoice(month: @month, overwrite: @overwrite)
       invoices << invoice unless invoice.nil?
     end
     invoices

--- a/app/models/concerns/registrar/book_keeping.rb
+++ b/app/models/concerns/registrar/book_keeping.rb
@@ -38,7 +38,6 @@ module Registrar::BookKeeping # rubocop:disable Metrics/ModuleLength
     lines.as_json
   end
 
-  # rubocop:disable Metrics/CognitiveComplexity
   def find_or_init_monthly_invoice(month:, overwrite:)
     invoice = invoices.find_by(monthly_invoice: true, issue_date: month.end_of_month.to_date)
     return invoice if invoice && !overwrite
@@ -51,7 +50,6 @@ module Registrar::BookKeeping # rubocop:disable Metrics/ModuleLength
 
     new_invoice
   end
-  # rubocop:enable Metrics/CognitiveComplexity
 
   def overwrite_invoice(original_invoice, new_invoice)
     params_to_scrub = %i[created_at updated_at id number sent_at

--- a/app/models/concerns/registrar/book_keeping.rb
+++ b/app/models/concerns/registrar/book_keeping.rb
@@ -38,6 +38,7 @@ module Registrar::BookKeeping # rubocop:disable Metrics/ModuleLength
     lines.as_json
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def find_or_init_monthly_invoice(month:, overwrite:)
     invoice = invoices.find_by(monthly_invoice: true, issue_date: month.end_of_month.to_date)
     return invoice if invoice && !overwrite
@@ -50,6 +51,7 @@ module Registrar::BookKeeping # rubocop:disable Metrics/ModuleLength
 
     new_invoice
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def overwrite_invoice(original_invoice, new_invoice)
     params_to_scrub = %i[created_at updated_at id number sent_at

--- a/app/models/concerns/registrar/book_keeping.rb
+++ b/app/models/concerns/registrar/book_keeping.rb
@@ -38,14 +38,25 @@ module Registrar::BookKeeping # rubocop:disable Metrics/ModuleLength
     lines.as_json
   end
 
-  def find_or_init_monthly_invoice(month:)
+  def find_or_init_monthly_invoice(month:, overwrite:)
     invoice = invoices.find_by(monthly_invoice: true, issue_date: month.end_of_month.to_date)
-    return invoice if invoice
+    return invoice if invoice && !overwrite
 
     summary = monthly_summary(month: month)
     return unless summary
 
-    init_monthly_invoice(summary)
+    new_invoice = init_monthly_invoice(summary)
+    return overwrite_invoice(invoice, new_invoice) if invoice && overwrite
+
+    new_invoice
+  end
+
+  def overwrite_invoice(original_invoice, new_invoice)
+    params_to_scrub = %i[created_at updated_at id number sent_at
+                         e_invoice_sent_at in_directo cancelled_at payment_link]
+    attrs = new_invoice.attributes.with_indifferent_access.except(*params_to_scrub)
+    original_invoice.update(attrs)
+    original_invoice
   end
 
   def title_for_summary(date)

--- a/app/models/concerns/registrar/book_keeping.rb
+++ b/app/models/concerns/registrar/book_keeping.rb
@@ -38,7 +38,7 @@ module Registrar::BookKeeping # rubocop:disable Metrics/ModuleLength
     lines.as_json
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/CognitiveComplexity
   def find_or_init_monthly_invoice(month:, overwrite:)
     invoice = invoices.find_by(monthly_invoice: true, issue_date: month.end_of_month.to_date)
     return invoice if invoice && !overwrite
@@ -51,7 +51,7 @@ module Registrar::BookKeeping # rubocop:disable Metrics/ModuleLength
 
     new_invoice
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/CognitiveComplexity
 
   def overwrite_invoice(original_invoice, new_invoice)
     params_to_scrub = %i[created_at updated_at id number sent_at


### PR DESCRIPTION
Added extra param overwrite for SendMonthlyInvoicesJob.perform_now(overwrite: false).
If true, existing monthly invoices data will be refreshed, except the following attributes:

created_at, updated_at, id, number, sent_at, e_invoice_sent_at, in_directo, cancelled_at, payment_link