### PR TITLE
Downgraded apipie gem to version 0.6.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 # core
 gem 'active_interaction', '~> 4.0'
-gem 'apipie-rails', '~> 0.9.0'
+gem 'apipie-rails', '~> 0.6.0'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'iso8601', '0.13.0' # for dates and times
 gem 'mimemagic', '0.4.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,9 +149,9 @@ GEM
     akami (1.3.1)
       gyoku (>= 0.4.0)
       nokogiri
-    apipie-rails (0.9.0)
-      actionpack (>= 5.0)
-      activesupport (>= 5.0)
+    apipie-rails (0.6.0)
+      actionpack (>= 4.1)
+      activesupport (>= 4.1)
     attr_required (1.0.1)
     autoprefixer-rails (10.2.4.0)
       execjs
@@ -535,7 +535,7 @@ PLATFORMS
 DEPENDENCIES
   active_interaction (~> 4.0)
   airbrake
-  apipie-rails (~> 0.9.0)
+  apipie-rails (~> 0.6.0)
   aws-sdk-sesv2 (~> 1.19)
   bootsnap (>= 1.1.0)
   bootstrap-sass (~> 3.4)


### PR DESCRIPTION
Problems with required: false params, still cannot accept params with nil or empty string values