### PR TITLE
Downgraded apipie back to version 0.6.0 due to a bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 # core
 gem 'active_interaction', '~> 4.0'
-gem 'apipie-rails', '~> 1.2.0'
+gem 'apipie-rails', '~> 1.2.1'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'iso8601', '0.13.0' # for dates and times
 gem 'mimemagic', '0.4.3'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 # core
 gem 'active_interaction', '~> 4.0'
-gem 'apipie-rails', '~> 1.2.1'
+gem 'apipie-rails', '~> 0.6.0'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'iso8601', '0.13.0' # for dates and times
 gem 'mimemagic', '0.4.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
     akami (1.3.1)
       gyoku (>= 0.4.0)
       nokogiri
-    apipie-rails (1.2.0)
+    apipie-rails (1.2.1)
       actionpack (>= 5.0)
       activesupport (>= 5.0)
     attr_required (1.0.1)
@@ -540,7 +540,7 @@ PLATFORMS
 DEPENDENCIES
   active_interaction (~> 4.0)
   airbrake
-  apipie-rails (~> 1.2.0)
+  apipie-rails (~> 1.2.1)
   aws-sdk-sesv2 (~> 1.19)
   bootsnap (>= 1.1.0)
   bootstrap-sass (~> 3.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,9 +149,9 @@ GEM
     akami (1.3.1)
       gyoku (>= 0.4.0)
       nokogiri
-    apipie-rails (1.2.1)
-      actionpack (>= 5.0)
-      activesupport (>= 5.0)
+    apipie-rails (0.6.0)
+      actionpack (>= 4.1)
+      activesupport (>= 4.1)
     attr_required (1.0.1)
     autoprefixer-rails (10.2.4.0)
       execjs
@@ -540,7 +540,7 @@ PLATFORMS
 DEPENDENCIES
   active_interaction (~> 4.0)
   airbrake
-  apipie-rails (~> 1.2.1)
+  apipie-rails (~> 0.6.0)
   aws-sdk-sesv2 (~> 1.19)
   bootsnap (>= 1.1.0)
   bootstrap-sass (~> 3.4)


### PR DESCRIPTION
Required: false attribute still being validated after update to version 1.2.0. Related to https://github.com/Apipie/apipie-rails/issues/709, supposed to be fixed in version 1.2.1, but did not succeed.