### PR TITLE
fixed logging spam

### DIFF
--- a/app/jobs/check_force_delete_lift.rb
+++ b/app/jobs/check_force_delete_lift.rb
@@ -17,7 +17,7 @@ class CheckForceDeleteLift < ApplicationJob
 
   def find_domains_to_lift_force_delete
     Domain.where("'#{DomainStatus::FORCE_DELETE}' = ANY (statuses)")
-          .select { |d| d.registrant.need_to_lift_force_delete? }
+          .select { |d| d.registrant.need_to_lift_force_delete? && d.contacts.all?(&:need_to_lift_force_delete?) }
   end
 
   def find_domains_to_process(domains)

--- a/app/jobs/check_force_delete_lift.rb
+++ b/app/jobs/check_force_delete_lift.rb
@@ -16,7 +16,7 @@ class CheckForceDeleteLift < ApplicationJob
   private
 
   def find_domains_to_lift_force_delete
-    Domain.where("'#{DomainStatus::FORCE_DELETE}' = ANY (statuses)")
+    Domain.where("'#{DomainStatus::FORCE_DELETE}' = ANY (statuses)").includes(:registrant, :contacts)
           .select { |d| d.registrant.need_to_lift_force_delete? && d.contacts.all?(&:need_to_lift_force_delete?) }
   end
 

--- a/app/jobs/check_force_delete_lift.rb
+++ b/app/jobs/check_force_delete_lift.rb
@@ -33,22 +33,16 @@ class CheckForceDeleteLift < ApplicationJob
       event = registrant.validation_events.last
       next if event.blank?
 
-      domain_list(event).each { |d| refresh_status_notes(d, registrant) }
+      refresh_status_notes(domain, registrant)
     end
-  end
-
-  def domain_list(event)
-    domain_contacts = Contact.where(email: event.email).map(&:domain_contacts).flatten
-    registrant_ids = Registrant.where(email: event.email).pluck(:id)
-
-    (domain_contacts.map(&:domain).flatten + Domain.where(registrant_id: registrant_ids)).uniq
   end
 
   def refresh_status_notes(domain, registrant)
     return unless domain.status_notes[DomainStatus::FORCE_DELETE]
 
-    domain.status_notes[DomainStatus::FORCE_DELETE].slice!(registrant.email_history)
+    domain.status_notes[DomainStatus::FORCE_DELETE].slice!(registrant.email_history || '')
     domain.status_notes[DomainStatus::FORCE_DELETE].lstrip!
-    domain.save(validate: false)
+
+    domain.save(validate: false) if domain.changed?
   end
 end


### PR DESCRIPTION
close #2607 

**What happened?**
- We encountered a problem: a massive amount of logs was generated, which doesn't carry meaningful information.

**Why did it happen?**
- Looking at the consequence, we have a callback in our code, which launches a whois update job with every commit to the database. There are two reasons for this: the first reason is an incorrectly selected dataset, where domains with the same name are looped through repeatedly. The second reason is the update of status_notes, even if there were no changes. Therefore, setting the validate: false flag is undesirable.

**What did I do?**
- I removed the code that repeatedly collects domains of the registrant and contacts, which are already in the dataset, as well as those domains that do not have the Force Delete status. At the same time, I put a check on the update of status_notes. This attribute will only be updated if some changes have been made to the domain.

**How to test?**
- You need to run the job in a test environment and make sure that spam is no longer being generated.
- Also, you need to create a domain that has met all the conditions to remove forced deletion and ensure that this job is working. 
- Also, since I set a condition for updating status notes, you need to make sure that status notes are also updated under the required conditions.

**How to review?**
- Make sure the code is clean.
- Ensure that the code does not introduce additional complexity.

**What other suggestions are there to improve the overall workflow?**
- Martin suggests an idea that the launch of the list force delete job should not be a mass event. That is, this job should be initiated only in two cases and only for a specific domain: when a user has changed an invalid email and when a user has extended the domain.