### PR TITLE
Unable to create contact with punnycode

### DIFF
--- a/app/interactions/actions/simple_mail_validator.rb
+++ b/app/interactions/actions/simple_mail_validator.rb
@@ -3,9 +3,7 @@ module Actions
     extend self
 
     def run(email:, level:)
-      local_part, domain = email.split('@')
-      decoded_domain = Addressable::IDNA.to_unicode(domain)
-      email = "#{local_part}@#{decoded_domain}"
+      email = decode_email_punycode(email)
 
       result = truemail_validate(email: email, level: level)
       result = validate_for_a_and_aaaa_records(email) if !result && level == :mx
@@ -34,6 +32,12 @@ module Actions
       return if Rails.env.test?
 
       logger.info "Validated #{type} record for #{email}. Validation result - #{result}"
+    end
+
+    def decode_email_punycode(email)
+      local_part, domain = email.split('@')
+      decoded_domain = Addressable::IDNA.to_unicode(domain)
+      "#{local_part}@#{decoded_domain}"
     end
 
     def logger

--- a/app/interactions/actions/simple_mail_validator.rb
+++ b/app/interactions/actions/simple_mail_validator.rb
@@ -3,6 +3,10 @@ module Actions
     extend self
 
     def run(email:, level:)
+      local_part, domain = email.split('@')
+      decoded_domain = Addressable::IDNA.to_unicode(domain)
+      email = "#{local_part}@#{decoded_domain}"
+
       result = truemail_validate(email: email, level: level)
       result = validate_for_a_and_aaaa_records(email) if !result && level == :mx
       result

--- a/test/interactions/email_check_test.rb
+++ b/test/interactions/email_check_test.rb
@@ -96,6 +96,13 @@ class EmailCheckTest < ActiveSupport::TestCase
     assert_equal contact_two.validation_events.count, 3
   end
 
+  def test_should_test_email_with_punnycode
+    email = "info@xn--energiathus-mfb.ee"
+    result = Actions::SimpleMailValidator.run(email: email, level: :mx)
+
+    assert result
+  end
+
   private
 
   def trumail_result


### PR DESCRIPTION
**What's the problem?**

- One of our clients is complaining that his email with a valid punnycode does not pass validation when creating a contact.

**What's the solution?**

- I added an additional method that parses the email's hostname and converts it to UTF format. After which, the transformed hostname is then checked by Truemail.

**How to test?**

- Ensure that valid emails with a standard hostname are being created.
- Ensure that valid emails with punnycode are being created.
- Ensure that invalid emails can't be created.
- Ensure that invalid emails with punnycode can't be created.

**How to review?**

- Check the code's frequency.
- Ensure the code doesn't complicate the logic.