### PR TITLE
added deadline registration condition during domain registration from…

### DIFF
--- a/app/interactions/actions/domain_create.rb
+++ b/app/interactions/actions/domain_create.rb
@@ -43,7 +43,7 @@ module Actions
       return unless Domain.release_to_auction
 
       dn = DNS::DomainName.new(domain.name)
-      if dn.at_auction?
+      if dn.at_auction? || dn.is_deadline_is_reached?
         domain.add_epp_error('2306', nil, nil, 'Parameter value policy error: domain is at auction')
       elsif dn.awaiting_payment?
         domain.add_epp_error('2003', nil, nil, 'Required parameter missing; reserved>pw element' \

--- a/app/models/dns/domain_name.rb
+++ b/app/models/dns/domain_name.rb
@@ -78,6 +78,10 @@ module DNS
       !not_auctionable?
     end
 
+    def is_deadline_is_reached?
+      pending_auction && pending_auction.payment_received? && pending_auction&.registration_deadline && Time.zone.now > pending_auction.registration_deadline
+    end
+
     def to_s
       name
     end

--- a/test/integration/repp/v1/stats/market_share_test.rb
+++ b/test/integration/repp/v1/stats/market_share_test.rb
@@ -24,7 +24,7 @@ class ReppV1StatsMarketShareTest < ActionDispatch::IntegrationTest
   end
 
   def test_shows_market_share_growth_rate_data
-    prev_date = Time.zone.today.last_month.strftime('%m.%y')
+    prev_date = Date.new(2023, 11, 1).strftime('%m.%y')
     get '/repp/v1/stats/market_share_growth_rate', headers: @auth_headers,
                                                    params: { q: { end_date: @today,
                                                                   compare_to_end_date: prev_date } }


### PR DESCRIPTION
fixes https://github.com/internetee/registry/issues/2641

**What is the problem?**
When a user wins an auction and receives a registration code, they have 30 days to register the domain. If the domain is not registered within this time frame, it goes back to the next round of the auction. Two tasks in the auction are responsible for this: DomainRegistrationCheckJob and ResultStatusUpdateJob. The first task reports on the auction statuses, while the second one checks if the domain is registered or not. When the DomainRegistrationCheckJob task indicates that the deadline has passed, a new status "domain_not_registered" is set for the auction, indicating that the domain is going for another round. At the same time, the registry should be notified about this so that domain registration stops because the deadline has passed. However, if a user who has won the domain decides to register it between the status update in the auction and the request for the new status in the registry, the domain will end up in both the auction and registered to the user.

**How is the problem solved?**
The auction also sends information about the registration deadline when the auction status is "payment_received." This attribute should be used to address this issue. If a user decides to register the domain after the deadline has passed, a comparison should be made between the current time and the deadline. If the user is late, an EPP 2306 error should be returned, indicating that the domain is already in the auction.

**How to test?**
To test this, win a domain in the auction and obtain the code. Set the domain status in the auction to "domain_not_registered." In the registry, set a date earlier than the current date for the auction model's "registration_deadline" attribute. Make sure the auction status is "payment_received," and then try to create a domain with the name of the auction you won.