### PR TITLE
Fix poll messages crashing

### DIFF
--- a/app/controllers/repp/v1/registrar/summary_controller.rb
+++ b/app/controllers/repp/v1/registrar/summary_controller.rb
@@ -59,6 +59,7 @@ module Repp
           # WHERE attached_obj_type = 'Epp::Domain' AND name IS NULL;
           message = 'orphan message, domain deleted, registrar should dequeue: '
           Rails.logger.error message + e.to_s
+          nil
         end
         # rubocop:enable Style/RescueStandardError
 

--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -3,6 +3,7 @@ class Action < ApplicationRecord
 
   belongs_to :user
   belongs_to :contact, optional: true
+  has_many :notifications, dependent: :nullify
   has_many :subactions, class_name: 'Action',
                         foreign_key: 'bulk_action_id',
                         inverse_of: :bulk_action,

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -13,6 +13,7 @@ class Notification < ApplicationRecord
 
   def mark_as_read
     raise 'Read notification cannot be marked as read again' if read?
+
     self.read = true
     save
   end


### PR DESCRIPTION
- Close internetee/registrar_center2#130
- Repp::V1::Registrar::SummaryController -> Added a return of nil after logging the error, ensuring the method returns a consistent value after an exception is caught.
- Created missing has_many relationship between the Action model and a Notification model. When an associated Action is deleted, the notifications related to it will have their foreign key set to null instead of being deleted, preserving the notifications while breaking the association.