### PR TITLE
feat: restore company validation for Estonian organizations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,8 +68,7 @@ gem 'pdfkit'
 gem 'redis'
 gem 'sidekiq', '~> 7.0'
 
-gem 'company_register', github: 'internetee/company_register',
-                        branch: '4-check-for-company-existence'
+gem 'company_register', github: 'internetee/company_register', branch: :master
 gem 'domain_name'
 gem 'e_invoice', github: 'internetee/e_invoice', branch: :master
 gem 'haml', '~> 6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/internetee/company_register.git
-  revision: 6465d5c49478b9de5a5fa009cb6b8123b3956dd1
-  branch: 4-check-for-company-existence
+  revision: 30b2c4d2f0bb882370e174fc965cd9fd02b42951
+  branch: master
   specs:
     company_register (0.1.0)
       activesupport
@@ -170,7 +170,7 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     bcrypt (3.1.16)
-    bigdecimal (3.1.8)
+    bigdecimal (3.1.9)
     bindata (2.5.0)
     bootsnap (1.17.1)
       msgpack (~> 1.2)
@@ -282,7 +282,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
-    json (2.5.1)
+    json (2.9.1)
     json-jwt (1.16.6)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -304,12 +304,15 @@ GEM
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
     libxml-ruby (3.2.1)
-    logger (1.4.3)
+    logger (1.6.4)
     loofah (2.24.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.7.1)
+    mail (2.8.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -321,7 +324,7 @@ GEM
       rake
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
-    minitest (5.25.1)
+    minitest (5.25.4)
     minitest-stub_any_instance (1.0.3)
     monetize (1.9.4)
       money (~> 6.12)
@@ -333,12 +336,17 @@ GEM
       money (~> 6.13.2)
       railties (>= 3.0)
     msgpack (1.7.2)
-    mutex_m (0.2.0)
+    mutex_m (0.3.0)
     net-ftp (0.3.7)
       net-protocol
       time
     net-http (0.6.0)
       uri
+    net-imap (0.4.18)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
     net-protocol (0.1.3)
       timeout
     net-smtp (0.3.3)
@@ -452,7 +460,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.3.9)
+    rexml (3.4.0)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -534,7 +542,7 @@ GEM
       simpleidn
     warden (1.2.9)
       rack (>= 2.0.9)
-    wasabi (5.0.3)
+    wasabi (5.1.0)
       addressable
       faraday (>= 1.9, < 3)
       nokogiri (>= 1.13.9)

--- a/app/interactions/actions/contact_create.rb
+++ b/app/interactions/actions/contact_create.rb
@@ -14,7 +14,7 @@ module Actions
       maybe_attach_legal_doc
       validate_ident
       maybe_change_email
-      # maybe_company_is_relevant
+      maybe_company_is_relevant
       commit
       validate_contact
     end
@@ -78,16 +78,17 @@ module Actions
       @error = true
     end
 
-    # def maybe_company_is_relevant
-    #   return true unless contact.org?
+    def maybe_company_is_relevant
+      return true unless contact.org?
+      return true unless contact.ident_country_code == 'EE'
 
-    #   company_status = contact.return_company_status
+      company_status = contact.return_company_status
 
-    #   return if [Contact::REGISTERED, Contact::LIQUIDATED].include? company_status
-    #   contact.add_epp_error('2003', nil, 'ident', I18n.t('errors.messages.company_not_registered'))
+      return true if [Contact::REGISTERED, Contact::LIQUIDATED].include? company_status
+      contact.add_epp_error('2003', nil, 'ident', I18n.t('errors.messages.company_not_registered'))
 
-    #   @error = true
-    # end
+      @error = true
+    end
 
     def maybe_attach_legal_doc
       ::Actions::BaseAction.attach_legal_doc_to_new(contact, legal_document, domain: false)

--- a/test/integration/repp/v1/contacts/create_test.rb
+++ b/test/integration/repp/v1/contacts/create_test.rb
@@ -188,39 +188,38 @@ class ReppV1ContactsCreateTest < ActionDispatch::IntegrationTest
     ENV['shunter_enabled'] = 'false'
   end
 
-  # def test_returns_error_response_if_company_not_existed
-  #   original_new_method = CompanyRegister::Client.method(:new)
-  #   CompanyRegister::Client.define_singleton_method(:new) do
-  #     object = original_new_method.call
-  #     def object.simple_data(registration_number:)
-  #       [Company.new('1234567', 'ACME Ltd', 'K')]
-  #     end
-  #     object
-  #   end
+  def test_returns_error_response_if_company_not_existed
+    original_new_method = CompanyRegister::Client.method(:new)
+    CompanyRegister::Client.define_singleton_method(:new) do
+      object = original_new_method.call
+      def object.simple_data(registration_number:)
+        [Company.new('1234567', 'ACME Ltd', 'K')]
+      end
+      object
+    end
 
-  #   request_body = {
-  #     "contact": {
-  #       "name": 'Donald Trump',
-  #       "phone": '+372.51111112',
-  #       "email": 'donald@trumptower.com',
-  #       "ident": {
-  #         "ident_type": 'org',
-  #         "ident_country_code": 'EE',
-  #         "ident": '70000313',
-  #       },
-  #     },
-  #   }
+    request_body = {
+      "contact": {
+        "name": 'Donald Trump',
+        "phone": '+372.51111112',
+        "email": 'donald@trumptower.com',
+        "ident": {
+          "ident_type": 'org',
+          "ident_country_code": 'EE',
+          "ident": '70000313',
+        },
+      },
+    }
 
-  #   post '/repp/v1/contacts', headers: @auth_headers, params: request_body
-  #   json = JSON.parse(response.body, symbolize_names: true)
+    post '/repp/v1/contacts', headers: @auth_headers, params: request_body
+    json = JSON.parse(response.body, symbolize_names: true)
 
-  #   assert_response :bad_request
-  #   assert_equal 2003, json[:code]
-  #   puts json[:message]
-  #   assert json[:message].include? 'Company is not registered'
+    assert_response :bad_request
+    assert_equal 2003, json[:code]
+    assert json[:message].include? 'Company is not registered'
 
-  #   CompanyRegister::Client.define_singleton_method(:new, original_new_method)
-  # end
+    CompanyRegister::Client.define_singleton_method(:new, original_new_method)
+  end
 
   def test_contact_created_with_existed_company
     original_new_method = CompanyRegister::Client.method(:new)


### PR DESCRIPTION
- Re-enable company validation logic for Estonian organization contacts
- Update company_register gem to use master branch
- Restore and update company validation tests
- Add additional check for Estonian country code in validation

This change ensures that only registered or liquidated Estonian companies can be used when creating organizational contacts.