### PR TITLE
Make admin contacts optional for private registrants

### DIFF
--- a/app/models/epp/domain.rb
+++ b/app/models/epp/domain.rb
@@ -114,7 +114,9 @@ class Epp::Domain < Domain
 
   def attach_default_contacts
     return if registrant.blank?
+
     registrant_obj = Contact.find_by(code: registrant.code)
+    return if registrant_obj.priv?
 
     tech_contacts << registrant_obj if tech_domain_contacts.blank?
     admin_contacts << registrant_obj if admin_domain_contacts.blank? && !registrant.org?


### PR DESCRIPTION
Close:
#2701 
#2702 

Binded to: https://github.com/internetee/registrar_center2/pull/135

This change makes admin contacts optional for private registrants while keeping them mandatory for organizations. The changes include:

- Updated Domain model validations to make admin and tech contacts optional (min=0) for private registrants
- Added validation rules methods to handle different requirements based on registrant type
- Modified EPP domain creation to support domains without admin contacts for private registrants
- Updated attach_default_contacts to skip adding contacts for private registrants
- Added comprehensive test coverage for:
  - Domain model validations with private/org registrants
  - EPP domain creation without admin contacts for private registrants
  - REPP API contact management for private registrants

This implements the requirement to make admin contacts optional for private registrations of .ee domains while maintaining the existing validation rules for organizations.