### PR TITLE
fix: handle company register API data type errors

### DIFF
--- a/app/jobs/company_register_status_job.rb
+++ b/app/jobs/company_register_status_job.rb
@@ -75,15 +75,18 @@ class CompanyRegisterStatusJob < ApplicationJob
   end
 
   def delete_process(contact)
+    Rails.logger.info("Processing company details for contact #{contact.id} with ident: #{contact.ident} (#{contact.ident.class})")
     company_details_response = contact.return_company_details
 
     if company_details_response.empty?
+      Rails.logger.info("Empty company details response for contact #{contact.id}")
       schedule_force_delete(contact)
 
       return
     end
 
     kandeliik_tekstina = extract_kandeliik_tekstina(company_details_response)
+    Rails.logger.info("Kandeliik tekstina for contact #{contact.id}: #{kandeliik_tekstina}")
 
     if kandeliik_tekstina == PAYMENT_STATEMENT_BUSINESS_REGISTRY_REASON
       soft_delete_company(contact)

--- a/app/models/contact/company_register.rb
+++ b/app/models/contact/company_register.rb
@@ -26,6 +26,7 @@ module Contact::CompanyRegister
 
   def return_company_details
     return unless org?
+    return [] unless ident.is_a?(String)
 
     company_register.company_details(registration_number: ident)
   rescue CompanyRegister::NotAvailableError


### PR DESCRIPTION
- Add type checking for contact ident before calling company register API
- Add logging for debugging company details processing
- Prevent TypeError when converting Symbol to Integer in company_register gem

The changes help to:
1. Prevent errors when contact ident is not a string
2. Improve debugging capabilities by logging API responses
3. Better handle edge cases in company register status checks