### PR TITLE
 add nil check for registrant in phone checker job

### DIFF
--- a/app/jobs/org_registrant_phone_checker_job.rb
+++ b/app/jobs/org_registrant_phone_checker_job.rb
@@ -27,6 +27,8 @@ class OrgRegistrantPhoneCheckerJob < ApplicationJob
 
   def execute_single_checker(registrant_user_code)
     registrant_user = Contact.where(ident_type: 'org', ident_country_code: 'EE').joins(:registrant_domains).find_by(code: registrant_user_code)
+    return if registrant_user.nil?
+
     is_phone_number_matching = check_the_registrant_phone_number(registrant_user)
 
     call_disclosure_action(is_phone_number_matching, registrant_user)


### PR DESCRIPTION
fix: add nil check for registrant in phone checker job

Add a guard clause to handle cases where registrant_user is not found in execute_single_checker method. This prevents potential NoMethodError when trying to check phone number for non-existent registrant.

Previously the method would raise an error when registrant_user_code was invalid or not found in the database.