### PR TITLE
feat: add admin contact ident type validation

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -27,12 +27,25 @@ module Admin
 
     def casted_settings
       settings = {}
-
+    
       params[:settings].each do |k, v|
-        settings[k] = { value: v }
+        setting = SettingEntry.find(k)
+        value = if setting.format == 'array'
+          processed_hash = available_options.each_with_object({}) do |option, hash|
+            hash[option] = (v[option] == "true")
+          end
+          processed_hash.to_json
+        else
+          v
+        end
+        settings[k] = { value: value }
       end
-
+    
       settings
+    end
+    
+    def available_options
+      %w[birthday priv org]
     end
   end
 end

--- a/app/models/epp/domain.rb
+++ b/app/models/epp/domain.rb
@@ -29,9 +29,8 @@ class Epp::Domain < Domain
     active_admins = admin_domain_contacts.select { |x| !x.marked_for_destruction? }
     active_techs = tech_domain_contacts.select { |x| !x.marked_for_destruction? }
 
-    # Проверка количества админ контактов
     if require_admin_contacts? && active_admins.empty?
-      add_epp_error('2306', 'contact', nil, 'Admin contacts are required')
+      add_epp_error('2306', 'contact', nil, 'Admin contact is required')
       ok = false
     end
 

--- a/app/models/epp/domain.rb
+++ b/app/models/epp/domain.rb
@@ -29,6 +29,12 @@ class Epp::Domain < Domain
     active_admins = admin_domain_contacts.select { |x| !x.marked_for_destruction? }
     active_techs = tech_domain_contacts.select { |x| !x.marked_for_destruction? }
 
+    # Проверка количества админ контактов
+    if require_admin_contacts? && active_admins.empty?
+      add_epp_error('2306', 'contact', nil, 'Admin contacts are required')
+      ok = false
+    end
+
     # validate registrant here as well
     ([Contact.find(registrant.id)] + active_admins + active_techs).each do |x|
       unless x.valid?

--- a/app/models/epp/domain.rb
+++ b/app/models/epp/domain.rb
@@ -36,6 +36,23 @@ class Epp::Domain < Domain
         ok = false
       end
     end
+
+    # Validate admin contacts ident type only for new domains or new admin contacts
+    allowed_types = Setting.admin_contacts_allowed_ident_type
+    if allowed_types.present?
+      active_admins.each do |admin_contact|
+        next if !new_record? && admin_contact.persisted? && !admin_contact.changed?
+        
+        contact = admin_contact.contact
+        unless allowed_types[contact.ident_type] == true
+          add_epp_error('2306', 'contact', contact.code, 
+            I18n.t('activerecord.errors.models.domain.admin_contact_invalid_ident_type',
+                   ident_type: contact.ident_type))
+          ok = false
+        end
+      end
+    end
+
     ok
   end
 
@@ -95,7 +112,8 @@ class Epp::Domain < Domain
         [:base, :key_data_not_allowed],
         [:period, :not_a_number],
         [:period, :not_an_integer],
-        [:registrant, :cannot_be_missing]
+        [:registrant, :cannot_be_missing],
+        [:admin_contacts, :invalid_ident_type]
       ],
       '2308' => [
         [:base, :domain_name_blocked, { value: { obj: 'name', val: name_dirty } }],
@@ -414,15 +432,15 @@ class Epp::Domain < Domain
   end
 
   def require_admin_contacts?
-    return true if registrant.org?
+    return true if registrant.org? && Setting.admin_contacts_required_for_org
     return false unless registrant.priv?
     
-    underage_registrant?
+    underage_registrant? && Setting.admin_contacts_required_for_minors
   end
 
   def tech_contacts_validation_rules(for_org:)
     {
-      min: 0, # Технический контакт опционален для всех
+      min: 0,
       max: -> { Setting.tech_contacts_max_count }
     }
   end

--- a/app/models/setting_entry.rb
+++ b/app/models/setting_entry.rb
@@ -87,6 +87,17 @@ class SettingEntry < ApplicationRecord
   end
 
   def array_format
-    JSON.parse(value).to_a
+    begin
+      if value.is_a?(String)
+        JSON.parse(value)
+      elsif value.is_a?(Hash)
+        value
+      else
+        { 'birthday' => true, 'priv' => true, 'org' => true }
+      end
+    rescue JSON::ParserError => e
+      puts "JSON Parse error: #{e.message}"
+      { 'birthday' => true, 'priv' => true, 'org' => true }
+    end
   end
 end

--- a/app/views/admin/settings/_setting_row.haml
+++ b/app/views/admin/settings/_setting_row.haml
@@ -1,6 +1,32 @@
 %tr{class: (@errors && @errors.has_key?(setting.code) && "danger")}
   %td.col-md-6= setting.code.humanize
-  - if [TrueClass, FalseClass].include?(setting.retrieve.class)
+  - if setting.format == 'array'
+    %td.col-md-6
+      - available_options = ['birthday', 'priv', 'org']
+      - begin
+        - raw_value = setting.retrieve
+        - current_values = if raw_value.is_a?(Hash)
+          - raw_value
+        - elsif raw_value.is_a?(Array) && raw_value.first.is_a?(Array)
+          - Hash[raw_value]
+        - elsif raw_value.is_a?(Array)
+          - available_options.each_with_object({}) { |opt, hash| hash[opt] = raw_value.include?(opt) }
+        - else
+          - begin
+            - parsed = JSON.parse(raw_value.to_s)
+            - parsed.is_a?(Hash) ? parsed : available_options.each_with_object({}) { |opt, hash| hash[opt] = true }
+          - rescue => e
+            - available_options.each_with_object({}) { |opt, hash| hash[opt] = true }
+      .row
+        - available_options.each do |option|
+          .col-md-4
+            .checkbox
+              %label
+                = check_box_tag "settings[#{setting.id}][#{option}]", "true", current_values[option], 
+                  id: "setting_#{setting.id}_#{option}",
+                  data: { value: current_values[option] }
+                = option.humanize
+  - elsif [TrueClass, FalseClass].include?(setting.retrieve.class)
     %td.col-md-6
       = hidden_field_tag("[settings][#{setting.id}]", '', id: nil)
       = check_box_tag("[settings][#{setting.id}]", true, setting.retrieve)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,7 @@ en:
 
         domain:
           <<: *epp_domain_ar_attributes
+          admin_contact_invalid_ident_type: "Administrative contact with identification type '%{ident_type}' is not allowed"
 
         nameserver:
           attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,7 +81,7 @@ en:
 
         domain:
           <<: *epp_domain_ar_attributes
-          admin_contact_invalid_ident_type: "Administrative contact with identification type '%{ident_type}' is not allowed"
+          admin_contact_invalid_ident_type: "Admin contact can be private person only"
 
         nameserver:
           attributes:

--- a/db/migrate/20250204094550_add_admin_contacts_rules_to_settings.rb
+++ b/db/migrate/20250204094550_add_admin_contacts_rules_to_settings.rb
@@ -1,0 +1,48 @@
+class AddAdminContactsRulesToSettings < ActiveRecord::Migration[6.1]
+  def up
+    unless SettingEntry.exists?(code: 'admin_contacts_required_for_org')
+      SettingEntry.create!(
+        code: 'admin_contacts_required_for_org',
+        value: 'true',
+        format: 'boolean',
+        group: 'domain_validation'
+      )
+    else
+      puts "SettingEntry admin_contacts_required_for_org already exists"
+    end
+
+    unless SettingEntry.exists?(code: 'admin_contacts_required_for_minors')
+      SettingEntry.create!(
+        code: 'admin_contacts_required_for_minors',
+        value: 'true',
+        format: 'boolean',
+        group: 'domain_validation'
+      )
+    else
+      puts "SettingEntry admin_contacts_required_for_minors already exists"
+    end
+
+    unless SettingEntry.exists?(code: 'admin_contacts_allowed_ident_type')
+      SettingEntry.create!(
+        code: 'admin_contacts_allowed_ident_type',
+        value: {
+          'birthday' => true,
+          'priv' => true,
+          'org' => false
+        }.to_json,
+        format: 'array',
+        group: 'domain_validation'
+      )
+    else
+      puts "SettingEntry admin_contacts_allowed_ident_type already exists"
+    end
+  end
+
+  def down
+    SettingEntry.where(code: [
+      'admin_contacts_required_for_org',
+      'admin_contacts_required_for_minors',
+      'admin_contacts_allowed_ident_type'
+    ]).destroy_all
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,6 +7,19 @@ ActiveRecord::Base.transaction do
   SettingEntry.create(code: 'directo_sales_agent', value: 'HELEN', format: 'string', group: 'billing')
   SettingEntry.create(code: 'admin_contacts_min_count', value: '1', format: 'integer', group: 'domain_validation')
   SettingEntry.create(code: 'admin_contacts_max_count', value: '10', format: 'integer', group: 'domain_validation')
+  SettingEntry.create(code: 'admin_contacts_required_for_org', value: 'true', format: 'boolean', group: 'domain_validation')
+  SettingEntry.create(code: 'admin_contacts_required_for_minors', value: 'true', format: 'boolean', group: 'domain_validation')
+  SettingEntry.create(
+    code: 'admin_contacts_allowed_ident_type', 
+    value: {
+      'birthday' => true,
+      'priv' => true,
+      'org' => true
+    }.to_json, 
+    format: 'array', 
+    group: 'domain_validation'
+  )
+
   SettingEntry.create(code: 'tech_contacts_min_count', value: '1', format: 'integer', group: 'domain_validation')
   SettingEntry.create(code: 'tech_contacts_max_count', value: '10', format: 'integer', group: 'domain_validation')
   SettingEntry.create(code: 'orphans_contacts_in_months', value: '6', format: 'integer', group: 'domain_validation')

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1169,6 +1169,38 @@ ALTER SEQUENCE public.epp_sessions_id_seq OWNED BY public.epp_sessions.id;
 
 
 --
+-- Name: free_domain_reservation_holders; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.free_domain_reservation_holders (
+    id bigint NOT NULL,
+    user_unique_id character varying NOT NULL,
+    domain_names character varying[] DEFAULT '{}'::character varying[],
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: free_domain_reservation_holders_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.free_domain_reservation_holders_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: free_domain_reservation_holders_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.free_domain_reservation_holders_id_seq OWNED BY public.free_domain_reservation_holders.id;
+
+
+--
 -- Name: invoice_items; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2675,7 +2707,8 @@ CREATE TABLE public.reserved_domains (
     updator_str character varying,
     legacy_id integer,
     name character varying NOT NULL,
-    password character varying NOT NULL
+    password character varying NOT NULL,
+    expire_at timestamp without time zone
 );
 
 
@@ -3183,6 +3216,13 @@ ALTER TABLE ONLY public.epp_logs ALTER COLUMN id SET DEFAULT nextval('public.epp
 --
 
 ALTER TABLE ONLY public.epp_sessions ALTER COLUMN id SET DEFAULT nextval('public.epp_sessions_id_seq'::regclass);
+
+
+--
+-- Name: free_domain_reservation_holders id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.free_domain_reservation_holders ALTER COLUMN id SET DEFAULT nextval('public.free_domain_reservation_holders_id_seq'::regclass);
 
 
 --
@@ -3712,6 +3752,14 @@ ALTER TABLE ONLY public.epp_logs
 
 ALTER TABLE ONLY public.epp_sessions
     ADD CONSTRAINT epp_sessions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: free_domain_reservation_holders free_domain_reservation_holders_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.free_domain_reservation_holders
+    ADD CONSTRAINT free_domain_reservation_holders_pkey PRIMARY KEY (id);
 
 
 --
@@ -5667,6 +5715,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20241030095636'),
 ('20241104104620'),
 ('20241112093540'),
-('20241112124405');
+('20241112124405'),
+('20241129095711'),
+('20241206085817'),
+('20250204094550');
 
 

--- a/test/fixtures/setting_entries.yml
+++ b/test/fixtures/setting_entries.yml
@@ -469,3 +469,27 @@ ip_whitelist_max_count:
   format: integer
   created_at: <%= Time.zone.parse('2010-07-05') %>
   updated_at: <%= Time.zone.parse('2010-07-05') %>
+
+admin_contacts_required_for_org:
+  code: admin_contacts_required_for_org
+  value: 'true'
+  group: domain_validation
+  format: boolean
+  created_at: <%= Time.zone.parse('2010-07-05') %>
+  updated_at: <%= Time.zone.parse('2010-07-05') %>
+
+admin_contacts_required_for_minors:
+  code: admin_contacts_required_for_minors
+  value: 'true'
+  group: domain_validation
+  format: boolean
+  created_at: <%= Time.zone.parse('2010-07-05') %>
+  updated_at: <%= Time.zone.parse('2010-07-05') %>
+
+admin_contacts_allowed_ident_type:
+  code: admin_contacts_allowed_ident_type
+  value: '{"birthday":true,"priv":true,"org":false}'
+  group: domain_validation
+  format: array
+  created_at: <%= Time.zone.parse('2010-07-05') %>
+  updated_at: <%= Time.zone.parse('2010-07-05') %>

--- a/test/integration/epp/domain/update/base_test.rb
+++ b/test/integration/epp/domain/update/base_test.rb
@@ -969,6 +969,98 @@ class EppDomainUpdateBaseTest < EppTestCase
     ENV["shunter_enabled"] = 'false'
   end
 
+  def test_does_not_update_domain_with_invalid_admin_contact_ident_type
+    admin_contact = contacts(:william)
+    admin_contact.update!(ident_type: 'org')
+
+    request_xml = <<-XML
+      <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+      <epp xmlns="#{Xsd::Schema.filename(for_prefix: 'epp-ee', for_version: '1.0')}">
+        <command>
+          <update>
+            <domain:update xmlns:domain="#{Xsd::Schema.filename(for_prefix: 'domain-ee', for_version: '1.2')}">
+              <domain:name>shop.test</domain:name>
+              <domain:add>
+                <domain:contact type="admin">#{admin_contact.code}</domain:contact>
+              </domain:add>
+            </domain:update>
+          </update>
+        </command>
+      </epp>
+    XML
+
+    post epp_update_path, params: { frame: request_xml },
+         headers: { 'HTTP_COOKIE' => 'session=api_bestnames' }
+    
+    response_xml = Nokogiri::XML(response.body)
+    assert_correct_against_schema response_xml
+    assert_epp_response :parameter_value_policy_error
+  end
+
+  def test_updates_domain_with_valid_admin_contact_ident_type
+    admin_contact = contacts(:william)
+    admin_contact.update!(ident_type: 'priv')
+
+    request_xml = <<-XML
+      <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+      <epp xmlns="#{Xsd::Schema.filename(for_prefix: 'epp-ee', for_version: '1.0')}">
+        <command>
+          <update>
+            <domain:update xmlns:domain="#{Xsd::Schema.filename(for_prefix: 'domain-ee', for_version: '1.2')}">
+              <domain:name>shop.test</domain:name>
+              <domain:add>
+                <domain:contact type="admin">#{admin_contact.code}</domain:contact>
+              </domain:add>
+            </domain:update>
+          </update>
+        </command>
+      </epp>
+    XML
+
+    post epp_update_path, params: { frame: request_xml },
+         headers: { 'HTTP_COOKIE' => 'session=api_bestnames' }
+    
+    response_xml = Nokogiri::XML(response.body)
+    assert_correct_against_schema response_xml
+    assert_epp_response :completed_successfully
+  end
+
+  def test_skips_admin_contact_ident_type_validation_for_existing_contacts
+    admin_contact = contacts(:william)
+    admin_contact.update!(ident_type: 'org')
+    @domain.admin_contacts << admin_contact
+    @domain.save!
+
+    # Change allowed types after domain is created
+    Setting.admin_contacts_allowed_ident_type = { 'birthday' => true, 'priv' => true, 'org' => false }
+
+    # Try to update domain with some other changes
+    request_xml = <<-XML
+      <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+      <epp xmlns="#{Xsd::Schema.filename(for_prefix: 'epp-ee', for_version: '1.0')}">
+        <command>
+          <update>
+            <domain:update xmlns:domain="#{Xsd::Schema.filename(for_prefix: 'domain-ee', for_version: '1.2')}">
+              <domain:name>shop.test</domain:name>
+              <domain:chg>
+                <domain:authInfo>
+                  <domain:pw>new_pw</domain:pw>
+                </domain:authInfo>
+              </domain:chg>
+            </domain:update>
+          </update>
+        </command>
+      </epp>
+    XML
+
+    post epp_update_path, params: { frame: request_xml },
+         headers: { 'HTTP_COOKIE' => 'session=api_bestnames' }
+    
+    response_xml = Nokogiri::XML(response.body)
+    assert_correct_against_schema response_xml
+    assert_epp_response :completed_successfully
+  end
+
   private
 
   def assert_verification_and_notification_emails

--- a/test/integration/repp/v1/domains/contacts_test.rb
+++ b/test/integration/repp/v1/domains/contacts_test.rb
@@ -142,7 +142,7 @@ class ReppV1DomainsContactsTest < ActionDispatch::IntegrationTest
 
     @domain.reload
     assert_response :bad_request
-    assert_equal 2004, json[:code]
+    assert_equal 2306, json[:code]
 
     assert @domain.admin_contacts.any?
   end
@@ -159,7 +159,7 @@ class ReppV1DomainsContactsTest < ActionDispatch::IntegrationTest
     json = JSON.parse(response.body, symbolize_names: true)
     
     assert_response :bad_request
-    assert_equal 2004, json[:code]
+    assert_equal 2306, json[:code]
     assert @domain.admin_contacts.any?
   end
 
@@ -178,7 +178,7 @@ class ReppV1DomainsContactsTest < ActionDispatch::IntegrationTest
     json = JSON.parse(response.body, symbolize_names: true)
     
     assert_response :bad_request
-    assert_equal 2004, json[:code]
+    assert_equal 2306, json[:code]
     assert @domain.admin_contacts.any?
   end
 
@@ -217,7 +217,7 @@ class ReppV1DomainsContactsTest < ActionDispatch::IntegrationTest
     json = JSON.parse(response.body, symbolize_names: true)
     
     assert_response :bad_request
-    assert_equal 2004, json[:code]
+    assert_equal 2306, json[:code]
     assert @domain.admin_contacts.any?
   end
 

--- a/test/models/domain/domain_version_test.rb
+++ b/test/models/domain/domain_version_test.rb
@@ -14,6 +14,7 @@ class DomainVersionTest < ActiveSupport::TestCase
   end
 
   def test_assigns_creator_to_paper_trail_whodunnit
+    Setting.admin_contacts_allowed_ident_type = { 'org' => true, 'priv' => true, 'birthday' => true }
     duplicate_domain = prepare_duplicate_domain
 
     PaperTrail.request.whodunnit = @user.id_role_username


### PR DESCRIPTION
- Add new setting for allowed admin contact ident types
- Add validation for admin contact ident types on domain create/update
- Add UI controls for managing allowed ident types
- Add tests for new validation rules
- Update domain model to respect new settings

The changes allow configuring which identification types (private person, organization, birthday) are allowed for administrative contacts. This is enforced when creating new domains or adding new admin contacts.