### PR TITLE
fix: prevent client_hold status from returning after manual removal

### DIFF
--- a/app/interactions/domains/client_hold/process_client_hold.rb
+++ b/app/interactions/domains/client_hold/process_client_hold.rb
@@ -5,16 +5,20 @@ module Domains
              class: Domain,
              description: 'Domain to set ClientHold on'
 
+      CLIENT_HOLD_SET_NOTE = "Has been set".freeze
+
       # rubocop:disable Metrics/AbcSize
       def execute
         notify_on_grace_period if should_notify_on_soft_force_delete?
 
         return unless client_holdable?
+        return if domain.force_delete_data['client_hold_mandatory'].to_s.downcase == CLIENT_HOLD_SET_NOTE.downcase
 
         domain.statuses << DomainStatus::CLIENT_HOLD
         to_stdout("DomainCron.start_client_hold: #{domain.id} (#{domain.name}) #{domain.changes}\n")
-
+        domain.force_delete_data['client_hold_mandatory'] = CLIENT_HOLD_SET_NOTE
         domain.save(validate: false)
+
         notify_client_hold
 
         to_stdout("Successfully set client_hold on (#{domain.name})")


### PR DESCRIPTION
- Add flag in force_delete_data to track manual client_hold removal
- Update ProcessClientHold to respect manual status removal
- Add test to verify client_hold doesn't return after admin removes it

When an admin manually removes the client_hold status from a domain, it should not be automatically re-added by the ProcessClientHold job. This change tracks manual removals and prevents the status from being re-added while maintaining the force delete process.

close #2742 