### PR TITLE
feat: support IPv6 /64 range in white IP validation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -155,6 +155,7 @@ en:
               ipv4_or_ipv6_must_be_present: 'IPv4 or IPv6 must be present'
               ip_must_be_one: 'Please enter only one IP address'
               ip_limit_exceeded: 'IP address limit exceeded. Total addresses: %{total}. Limit: %{limit}.'
+              ipv6_must_be_single_or_64_range: 'IPv6 address must be either a single address or a /64 range'
             ipv4:
               taken: 'has already been taken'
             ipv6:

--- a/test/integration/repp/v1/white_ips/create_test.rb
+++ b/test/integration/repp/v1/white_ips/create_test.rb
@@ -61,7 +61,7 @@ class ReppV1WhiteIpsCreateTest < ActionDispatch::IntegrationTest
     refute ActionMailer::Base.deliveries.last
   end
 
-  def test_validates_ip_max_count
+  def test_validates_ipv6_range
     request_body = {
       white_ip: {
         address: '2001:db8::/120',
@@ -73,7 +73,7 @@ class ReppV1WhiteIpsCreateTest < ActionDispatch::IntegrationTest
     json = JSON.parse(response.body, symbolize_names: true)
 
     assert_response :bad_request
-    assert json[:message].include? 'IP address limit exceeded'
+    assert json[:message].include? 'IPv6 address must be either a single address or a /64 range'
   end
 
   def test_returns_error_response_if_throttled

--- a/test/models/white_ip_test.rb
+++ b/test/models/white_ip_test.rb
@@ -53,6 +53,35 @@ class WhiteIpTest < ActiveSupport::TestCase
     assert_not WhiteIp.include_ip?('192.168.1.1')
   end
 
+  def test_validates_ipv6_64_range
+    white_ip = WhiteIp.new
+    white_ip.registrar = registrars(:bestnames)
+    white_ip.ipv6 = '2001:db8::/64'
+    
+    assert white_ip.valid?, 'IPv6 /64 range should be valid'
+  end
+
+  def test_validates_ipv6_single_address
+    white_ip = WhiteIp.new
+    white_ip.registrar = registrars(:bestnames)
+    white_ip.ipv6 = '2001:db8::1'
+    
+    assert white_ip.valid?, 'Single IPv6 address should be valid'
+  end
+
+  def test_rejects_invalid_ipv6_range
+    white_ip = WhiteIp.new
+    white_ip.registrar = registrars(:bestnames)
+    
+    white_ip.ipv6 = '2001:db8::/48'
+    assert white_ip.invalid?, 'IPv6 /48 range should be invalid'
+    assert_includes white_ip.errors.full_messages, 'IPv6 address must be either a single address or a /64 range'
+
+    white_ip.ipv6 = '2001:db8::/96'
+    assert white_ip.invalid?, 'IPv6 /96 range should be invalid'
+    assert_includes white_ip.errors.full_messages, 'IPv6 address must be either a single address or a /64 range'
+  end
+
   private
 
   def valid_white_ip


### PR DESCRIPTION
close #2769 

- Split IP validation logic for IPv4 and IPv6 addresses
- Add specific validation for IPv6 to allow only single addresses (/128) or /64 ranges
- Remove old network address calculation for IPv6
- Keep IPv4 address limit validation unchanged
- Add localization for new IPv6 validation error message
- Add test coverage for IPv6 validation:
  * Test for valid /64 range
  * Test for valid single address
  * Test for invalid ranges (/48 and /96)