### PR TITLE
feat: Add lifted force delete domains to daily admin notification

### DIFF
--- a/app/interactions/domains/cancel_force_delete/remove_force_delete_statuses.rb
+++ b/app/interactions/domains/cancel_force_delete/remove_force_delete_statuses.rb
@@ -15,6 +15,10 @@ module Domains
         rejected_statuses = domain.statuses.reject { |a| domain_statuses.include? a }
         domain.statuses = rejected_statuses
         domain.skip_whois_record_update = true
+        domain.lift_force_delete_domain_statuses_history_data = {
+          reason: domain.status_notes[DomainStatus::FORCE_DELETE],
+          date: Time.zone.now
+        }
         domain.save(validate: false)
       end
     end

--- a/app/interactions/domains/force_delete/set_status.rb
+++ b/app/interactions/domains/force_delete/set_status.rb
@@ -6,6 +6,10 @@ module Domains
         type == :fast_track ? force_delete_fast_track : force_delete_soft
         domain.status_notes[DomainStatus::FORCE_DELETE] = "Company no: #{domain.registrant.ident}" if reason == 'invalid_company'
         domain.skip_whois_record_update = true
+        domain.force_delete_domain_statuses_history_data = {
+          reason: domain.status_notes[DomainStatus::FORCE_DELETE],
+          date: Time.zone.now
+        }
         domain.save(validate: false)
       end
 

--- a/app/jobs/force_delete_daily_admin_notifier_job.rb
+++ b/app/jobs/force_delete_daily_admin_notifier_job.rb
@@ -8,9 +8,10 @@ class ForceDeleteDailyAdminNotifierJob < ApplicationJob
   private
 
   def force_deleted_domains
-    Domain.where("force_delete_start >= ? AND force_delete_start <= ?", 
-                 Time.zone.yesterday.beginning_of_day, 
-                 Time.zone.yesterday.end_of_day)
+    Domain.where("json_statuses_history->>'force_delete_domain_statuses_history_data' IS NOT NULL").
+          where("(json_statuses_history->'force_delete_domain_statuses_history_data'->>'date')::timestamp >= ? AND (json_statuses_history->'force_delete_domain_statuses_history_data'->>'date')::timestamp <= ?",
+                Time.zone.yesterday.beginning_of_day,
+                Time.zone.yesterday.end_of_day)
   end
 
   def lifted_force_delete_domains

--- a/app/jobs/force_delete_daily_admin_notifier_job.rb
+++ b/app/jobs/force_delete_daily_admin_notifier_job.rb
@@ -1,23 +1,33 @@
 class ForceDeleteDailyAdminNotifierJob < ApplicationJob
   queue_as :default
 
-  def perform
-    domains = Domain.where("'#{DomainStatus::FORCE_DELETE}' = ANY (statuses)")
-                    .where("force_delete_start = ?", Time.zone.now)
-
-    return if domains.empty?
-
-    notify_admins(domains)
+  def perform()
+    notify_about_force_deleted_domains(force_deleted_domains, lifted_force_delete_domains)
   end
 
   private
 
-  def notify_admins(domains)
-    summary = generate_summary(domains)
-    AdminMailer.force_delete_daily_summary(summary).deliver_now
+  def force_deleted_domains
+    Domain.where("force_delete_start >= ? AND force_delete_start <= ?", 
+                 Time.zone.yesterday.beginning_of_day, 
+                 Time.zone.yesterday.end_of_day)
   end
 
-  def generate_summary(domains)
+  def lifted_force_delete_domains
+    Domain.where("json_statuses_history->>'lift_force_delete_domain_statuses_history_data' IS NOT NULL")
+          .where("(json_statuses_history->'lift_force_delete_domain_statuses_history_data'->>'date')::timestamp >= ? AND (json_statuses_history->'lift_force_delete_domain_statuses_history_data'->>'date')::timestamp <= ?",
+                Time.zone.yesterday.beginning_of_day,
+                Time.zone.yesterday.end_of_day)
+  end
+
+  def notify_about_force_deleted_domains(force_deleted_domains, lifted_force_delete_domains)
+    force_deleted_summary = generate_summary_for_force_deleted_domains(force_deleted_domains)
+    lifted_force_delete_summary = generate_summary_for_lifted_force_delete_domains(lifted_force_delete_domains)
+
+    AdminMailer.force_delete_daily_summary(force_deleted_summary, lifted_force_delete_summary).deliver_now
+  end
+
+  def generate_summary_for_force_deleted_domains(domains)
     domains.map do |domain|
       {
         name: domain.name,
@@ -25,6 +35,16 @@ class ForceDeleteDailyAdminNotifierJob < ApplicationJob
         force_delete_type: domain.force_delete_type,
         force_delete_start: domain.force_delete_start,
         force_delete_date: domain.force_delete_date
+      }
+    end
+  end
+
+  def generate_summary_for_lifted_force_delete_domains(domains)
+    domains.map do |domain|
+      {
+        name: domain.name,
+        reason: domain.json_statuses_history.dig('lift_force_delete_domain_statuses_history_data', 'reason') || 'No reason provided',
+        date: domain.json_statuses_history.dig('lift_force_delete_domain_statuses_history_data', 'date')
       }
     end
   end

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,9 +1,10 @@
 class AdminMailer < ApplicationMailer
-  def force_delete_daily_summary(domains_summary)
-    @domains = domains_summary
+  def force_delete_daily_summary(force_deleted_summary, lifted_force_delete_summary)
+    @force_deleted_domains = force_deleted_summary
+    @lifted_domains = lifted_force_delete_summary
     mail(
       to: ENV['admin_notification_email'] || 'admin@registry.test',
       subject: "Force Delete Daily Summary - #{Date.current}"
     )
   end
-end 
+end

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -48,7 +48,8 @@ class Domain < ApplicationRecord
 
   store_accessor :json_statuses_history,
                  :force_delete_domain_statuses_history,
-                 :admin_store_statuses_history
+                 :admin_store_statuses_history,
+                 :lift_force_delete_domain_statuses_history_data
 
   # TODO: whois requests ip whitelist for full info for own domains and partial info for other domains
   # TODO: most inputs should be trimmed before validation, probably some global logic?

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -49,7 +49,8 @@ class Domain < ApplicationRecord
   store_accessor :json_statuses_history,
                  :force_delete_domain_statuses_history,
                  :admin_store_statuses_history,
-                 :lift_force_delete_domain_statuses_history_data
+                 :lift_force_delete_domain_statuses_history_data,
+                 :force_delete_domain_statuses_history_data
 
   # TODO: whois requests ip whitelist for full info for own domains and partial info for other domains
   # TODO: most inputs should be trimmed before validation, probably some global logic?

--- a/app/views/admin_mailer/force_delete_daily_summary.html.erb
+++ b/app/views/admin_mailer/force_delete_daily_summary.html.erb
@@ -31,7 +31,7 @@
 </table> 
 
 <h2>Lifted Force Delete Domains</h2>
-
+<table>
   <thead>
     <tr>
       <th>Domain</th>

--- a/app/views/admin_mailer/force_delete_daily_summary.html.erb
+++ b/app/views/admin_mailer/force_delete_daily_summary.html.erb
@@ -1,5 +1,6 @@
 <h1>Force Delete Daily Summary - <%= Date.current %></h1>
 
+<h2>Force Deleted Domains</h2>
 <table>
   <thead>
     <tr>
@@ -11,13 +12,43 @@
     </tr>
   </thead>
   <tbody>
-    <% @domains.each do |domain| %>
+    <% if @force_deleted_domains.present? %>
+      <% @force_deleted_domains.each do |domain| %>
+        <tr>
+          <td><%= domain[:name] %></td>
+          <td><%= domain[:reason] %></td>
+          <td><%= domain[:force_delete_type] %></td>
+          <td><%= domain[:force_delete_start]&.to_date %></td>
+          <td><%= domain[:force_delete_date]&.to_date %></td>
+        </tr>
+      <% end %>
+    <% else %>
       <tr>
-        <td><%= domain[:name] %></td>
-        <td><%= domain[:reason] %></td>
-        <td><%= domain[:force_delete_type] %></td>
-        <td><%= domain[:force_delete_start]&.to_date %></td>
-        <td><%= domain[:force_delete_date]&.to_date %></td>
+        <td colspan="5">No force deleted domains found</td>
+      </tr>
+    <% end %>
+  </tbody>
+</table> 
+
+<h2>Lifted Force Delete Domains</h2>
+
+  <thead>
+    <tr>
+      <th>Domain</th>
+      <th>Reason</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% if @lifted_domains.present? %>
+      <% @lifted_domains.each do |domain| %>
+        <tr>
+          <td><%= domain[:name] %></td>
+          <td><%= domain[:reason] %></td>
+        </tr>
+      <% end %>
+    <% else %>
+      <tr>
+        <td colspan="1">No lifted domains found</td>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
Closes #2772 

- Add tracking of lifted force delete domains with reason and date in json_statuses_history
- Modify ForceDeleteDailyAdminNotifierJob to include both force deleted and lifted domains
- Update admin mailer template to show separate tables for force deleted and lifted domains
- Update tests to reflect new functionality and fix timing issues with yesterday's data

Key changes:
- Store lift reason and date when canceling force delete
- Add new query method for finding lifted force delete domains
- Split email template into two sections
- Fix tests to properly handle the yesterday time window