### PR TITLE
Fix stale data in Whois update job by moving callback to after_commit

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -539,12 +539,16 @@ class Contact < ApplicationRecord
   end
 
   def update_related_whois_records
+    Rails.logger.info "\n\n============ update_related_whois_records ==========="
     # not doing anything if no real changes
     ignored_columns = %w[updated_at created_at statuses status_notes]
+    Rails.logger.info saved_changes.slice(*(self.class.column_names - ignored_columns)).empty?
     return if saved_changes.slice(*(self.class.column_names - ignored_columns)).empty?
 
     names = related_domain_descriptions.keys
+    Rails.logger.info "names: #{names}"
     UpdateWhoisRecordJob.perform_later(names, 'domain') if names.present?
+    Rails.logger.info "============\n\n" 
   end
 
   def children_log

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -85,8 +85,7 @@ class Contact < ApplicationRecord
                                                                                 country_code: country_code) },
               mapping: [%w[ident code], %w[ident_type type], %w[ident_country_code country_code]]
 
-  # after_save :update_related_whois_records
-  after_commit :update_related_whois_records
+  after_save :update_related_whois_records
   before_validation :clear_address_modifications, if: -> { !self.class.address_processing? }
 
   # TODO: remove after testing
@@ -540,20 +539,13 @@ class Contact < ApplicationRecord
   end
 
   def update_related_whois_records
-    Rails.logger.info "\n\n============ update_related_whois_records ==========="
     # not doing anything if no real changes
     ignored_columns = %w[updated_at created_at statuses status_notes]
-    Rails.logger.info "Contact: #{self.inspect}\n"
-    Rails.logger.info "Saved changes: #{saved_changes}"
 
-    
-    # return if saved_changes.slice(*(self.class.column_names - ignored_columns)).empty?
     return if (previous_changes.keys - ignored_columns).empty?
 
     names = related_domain_descriptions.keys
-    Rails.logger.info "names: #{names}"
     UpdateWhoisRecordJob.perform_later(names, 'domain') if names.present?
-    Rails.logger.info "============\n\n" 
   end
 
   def children_log

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -85,7 +85,7 @@ class Contact < ApplicationRecord
                                                                                 country_code: country_code) },
               mapping: [%w[ident code], %w[ident_type type], %w[ident_country_code country_code]]
 
-  after_save :update_related_whois_records
+  after_commit :update_related_whois_records
   before_validation :clear_address_modifications, if: -> { !self.class.address_processing? }
 
   # TODO: remove after testing

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -542,7 +542,10 @@ class Contact < ApplicationRecord
     Rails.logger.info "\n\n============ update_related_whois_records ==========="
     # not doing anything if no real changes
     ignored_columns = %w[updated_at created_at statuses status_notes]
-    Rails.logger.info saved_changes.slice(*(self.class.column_names - ignored_columns)).empty?
+    Rails.logger.info "Contact: #{self.inspect}\n"
+    Rails.logger.info "Saved changes: #{saved_changes}"
+
+    
     return if saved_changes.slice(*(self.class.column_names - ignored_columns)).empty?
 
     names = related_domain_descriptions.keys

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -85,7 +85,8 @@ class Contact < ApplicationRecord
                                                                                 country_code: country_code) },
               mapping: [%w[ident code], %w[ident_type type], %w[ident_country_code country_code]]
 
-  after_save :update_related_whois_records
+  # after_save :update_related_whois_records
+  after_commit :update_related_whois_records
   before_validation :clear_address_modifications, if: -> { !self.class.address_processing? }
 
   # TODO: remove after testing
@@ -546,7 +547,8 @@ class Contact < ApplicationRecord
     Rails.logger.info "Saved changes: #{saved_changes}"
 
     
-    return if saved_changes.slice(*(self.class.column_names - ignored_columns)).empty?
+    # return if saved_changes.slice(*(self.class.column_names - ignored_columns)).empty?
+    return if (previous_changes.keys - ignored_columns).empty?
 
     names = related_domain_descriptions.keys
     Rails.logger.info "names: #{names}"

--- a/test/tasks/emails/verify_email_task_test.rb
+++ b/test/tasks/emails/verify_email_task_test.rb
@@ -54,7 +54,7 @@ class VerifyEmailTaskTest < ActiveJob::TestCase
   end
 
   def test_should_verify_contact_email_which_was_not_verified
-    
+    ValidationEvent.delete_all
     assert_equal ValidationEvent.count, 0
     
     run_task


### PR DESCRIPTION
Related #https://github.com/internetee/rest-whois/issues/429

Previously, the UpdateWhoisRecordJob was enqueued from an after_save callback, which caused the job to run before the contact changes were committed to the database. As a result, the WHOIS record was updated with outdated contact data (e.g., previous email address), causing a one-step delay in data synchronization.

This PR moves the enqueue logic to an after_commit callback, ensuring that the job is triggered only after the transaction is fully committed and the latest data is visible to the Sidekiq worker.

Changes made:
- Moved update_related_whois_records from after_save to after_commit.
- Replaced saved_changes with previous_changes for accuracy post-commit.
- Added guard to skip WHOIS update if only ignored fields changed.

This ensures that WHOIS records reflect the actual latest contact information immediately after each update.
