### PR TITLE
updated set_test_date_to_api_user method on api_users_controller. #2816

### DIFF
--- a/app/controllers/admin/api_users_controller.rb
+++ b/app/controllers/admin/api_users_controller.rb
@@ -60,9 +60,9 @@ module Admin
         Actions::RecordDateOfTest.record_result_to_api_user(api_user:user_api,
                                                             date: demo_user_api['accreditation_date']) unless demo_user_api.empty?
         
-        redirect_to request.referrer, notice: 'User Api found'                                                    
+        redirect_to request.referrer, notice: 'User API found'                                                    
       when "404"
-        redirect_to request.referrer, notice: 'User Api not found or not accredited yet'
+        redirect_to request.referrer, notice: 'User API not found or not accredited yet'
       else
         redirect_to request.referrer, notice: 'Something went wrong'
       end

--- a/app/controllers/admin/api_users_controller.rb
+++ b/app/controllers/admin/api_users_controller.rb
@@ -52,18 +52,20 @@ module Admin
 
       response = base_get_request(uri: uri, port: ENV['registry_demo_registrar_port'])
 
-      if response.code == "200"
+      case response.code
+      when "200"
         result = JSON.parse(response.body)
         demo_user_api = result['user_api']
 
         Actions::RecordDateOfTest.record_result_to_api_user(api_user:user_api,
                                                             date: demo_user_api['accreditation_date']) unless demo_user_api.empty?
-        return redirect_to request.referrer, notice: 'User Api found'
+        
+        redirect_to request.referrer, notice: 'User Api found'                                                    
+      when "404"
+        redirect_to request.referrer, notice: 'User Api not found or not accredited yet'
       else
-        return redirect_to request.referrer, notice: 'User Api no found or not accriditated yet'
+        redirect_to request.referrer, notice: 'Something went wrong'
       end
-
-      redirect_to request.referrer, notice: 'Something goes wrong'
     end
 
     def remove_test_date_to_api_user


### PR DESCRIPTION
Bug fix #2816

On 'api_users_controller'  method 'set_test_date_to_api_user' notice 'Something went wrong' was''nt called because of last return on if-else block.

Modified:
1. Replaced if-else with switch statements for better code handling and readability. Plus possible future enhancement for adding new error codes.
2. Remvoed 'return' because redirect breaks out of the cycle anyway.
3. Added 'Something went wrong' notice to else(default) case if everything elese fails.
4. Fixed few typos on notice strings.