### PR TITLE
feat: Add system disclosed attributes for contact phone numbers

### DIFF
--- a/app/jobs/org_registrant_phone_checker_job.rb
+++ b/app/jobs/org_registrant_phone_checker_job.rb
@@ -54,9 +54,10 @@ class OrgRegistrantPhoneCheckerJob < ApplicationJob
     if is_phone_number_matching
       disclose_phone_number(contact)
       log("Phone number disclosed for registrant user #{contact.code}. Phone number: #{contact.phone}")
-    elsif contact.disclosed_attributes.include?('phone')
+    elsif contact.disclosed_attributes.include?('phone') || contact.system_disclosed_attributes.include?('phone')
       log("Removing phone number from disclosed attributes for registrant user #{contact.code}. Phone number: #{contact.phone}")
       contact.disclosed_attributes.delete('phone')
+      contact.system_disclosed_attributes.delete('phone')
       contact.save!
     else
       log("Phone number not disclosed for registrant user #{contact.code}. Phone number: #{contact.phone}")
@@ -69,6 +70,7 @@ class OrgRegistrantPhoneCheckerJob < ApplicationJob
 
   def disclose_phone_number(contact)
     contact.disclosed_attributes << 'phone'
+    contact.system_disclosed_attributes << 'phone'
     contact.save!
   end
 

--- a/db/migrate/20250627084536_add_system_disclosed_attributes_to_contact.rb
+++ b/db/migrate/20250627084536_add_system_disclosed_attributes_to_contact.rb
@@ -1,0 +1,5 @@
+class AddSystemDisclosedAttributesToContact < ActiveRecord::Migration[6.1]
+  def change
+    add_column :contacts, :system_disclosed_attributes, :string, array: true, default: []
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -697,7 +697,8 @@ CREATE TABLE public.contacts (
     company_register_status character varying,
     ident_request_sent_at timestamp without time zone,
     verified_at timestamp without time zone,
-    verification_id character varying
+    verification_id character varying,
+    system_disclosed_attributes character varying[] DEFAULT '{}'::character varying[]
 );
 
 
@@ -5728,6 +5729,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250204094550'),
 ('20250219102811'),
 ('20250313122119'),
-('20250319104749');
+('20250319104749'),
+('20250627084536');
 
 

--- a/lib/serializers/registrant_api/contact.rb
+++ b/lib/serializers/registrant_api/contact.rb
@@ -31,6 +31,7 @@ module Serializers
           auth_info: contact.auth_info,
           statuses: contact.statuses,
           disclosed_attributes: contact.disclosed_attributes,
+          system_disclosed_attributes: contact.system_disclosed_attributes,
           registrant_publishable: contact.registrant_publishable,
         }
 


### PR DESCRIPTION
- Add system_disclosed_attributes array column to contacts table
- Update OrgRegistrantPhoneCheckerJob to manage both user and system disclosed attributes
- Include system_disclosed_attributes in contact API serializer

This change introduces a new way to track system-level disclosure of contact attributes, separate from user-defined disclosures. When a phone number matches the company register data, it will be marked as disclosed both in user and system attributes. This allows better tracking of which attributes were automatically disclosed by the system versus manually disclosed by users.