### PR TITLE
feat(admin): notify registrar about domain status changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ruby:3.0.3-slim-buster
+FROM --platform=linux/amd64 ruby:3.0.3-bullseye
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends > /dev/null \
@@ -29,27 +29,27 @@ RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends > /
     && rm -rf /var/lib/apt/lists/*
 
 # add repository for Node.js in the LTS version
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
 
 RUN apt-get install -y --no-install-recommends > /dev/null \
-  nodejs=* \
-  qt5-default=* \
-  libqt5webkit5-dev=* \
-  gstreamer1.0-plugins-base=* \
-  libappindicator3-1=* \
-  gstreamer1.0-tools=* \
-  qtdeclarative5-dev=* \
-  fonts-liberation=* \
-  gstreamer1.0-x=* \
-  libasound2=* \
-  libnspr4=* \
-  libnss3=* \
-  libxss1=* \
-  libxtst6=* \
-  xdg-utils=* \
-  qtdeclarative5-dev=* \
-  fonts-liberation=* \
-  gstreamer1.0-x=* \
+  nodejs \
+  qtbase5-dev \
+  libqt5webkit5-dev \
+  gstreamer1.0-plugins-base \
+  libappindicator3-1 \
+  gstreamer1.0-tools \
+  qtdeclarative5-dev \
+  fonts-liberation \
+  gstreamer1.0-x \
+  libasound2 \
+  libnspr4 \
+  libnss3 \
+  libxss1 \
+  libxtst6 \
+  xdg-utils \
+  qtdeclarative5-dev \
+  fonts-liberation \
+  gstreamer1.0-x \
   wkhtmltopdf \
   libxslt1-dev \
   libxml2-dev \

--- a/app/controllers/admin/domains_controller.rb
+++ b/app/controllers/admin/domains_controller.rb
@@ -119,11 +119,13 @@ module Admin
       removed = old_statuses - new_statuses
       added   = new_statuses - old_statuses
   
-      msg = []
-      msg << "Set on #{@domain.name}: #{added.join(', ')}" unless added.empty?
-      msg << "Removed from #{@domain.name}: #{removed.join(', ')}" unless removed.empty?
+      added.each do |status|
+        @domain.registrar.notifications.create!(text: "#{status} set on domain #{@domain.name}")
+      end
 
-      @domain.registrar.notifications.create!(text: msg.join('. ')) if msg.any?
+      removed.each do |status|
+        @domain.registrar.notifications.create!(text: "#{status} is cancelled on domain #{@domain.name}")
+      end
     end
 
     def build_associations

--- a/test/integration/domain/domains_controller_test.rb
+++ b/test/integration/domain/domains_controller_test.rb
@@ -14,9 +14,13 @@ class DomainsControllerTest < ApplicationIntegrationTest
     # Status OK is removed because, if:
     # (statuses.length > 1) || !valid?
     # then status OK is removed by manage_automatic_statuses method in domain.rb
-    assert_equal "Set on #{domains(:shop).name}: #{DomainStatus::PENDING_UPDATE}. Removed from #{domains(:shop).name}: #{DomainStatus::OK}", domains(:shop).registrar.notifications.last.text
+    notifications = domains(:shop).registrar.notifications.last(2)
+    assert_equal "#{DomainStatus::PENDING_UPDATE} set on domain #{domains(:shop).name}", notifications.first.text
+    assert_equal "#{DomainStatus::OK} is cancelled on domain #{domains(:shop).name}", notifications.last.text
     
     patch admin_domain_path(domains(:shop)), params: { domain: { statuses: [DomainStatus::PENDING_DELETE_CONFIRMATION] } }
-    assert_equal "Set on #{domains(:shop).name}: #{DomainStatus::PENDING_DELETE_CONFIRMATION}. Removed from #{domains(:shop).name}: #{DomainStatus::PENDING_UPDATE}", domains(:shop).registrar.notifications.last.text
+    notifications = domains(:shop).registrar.notifications.last(2)
+    assert_equal "#{DomainStatus::PENDING_DELETE_CONFIRMATION} set on domain #{domains(:shop).name}", notifications.first.text
+    assert_equal "#{DomainStatus::PENDING_UPDATE} is cancelled on domain #{domains(:shop).name}", notifications.last.text
   end
 end


### PR DESCRIPTION
close #2823

- Add inform_registrar_about_status_changes method to detect added and removed statuses after domain update.
- Send notification to registrar with details of which statuses were set and which were removed.
- Integrate notification logic into domain update action.