### PR TITLE
Add e-invoice opt-out for PDF invoices

### DIFF
--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -58,6 +58,7 @@ RUN gem install bundler && \
 COPY . .
 
 # Copy sample config for asset precompilation (real values come from env at runtime)
+<<<<<<< HEAD
 RUN cp config/application.yml.sample config/application.yml && \
     cp config/database.yml.sample config/database.yml
 
@@ -65,6 +66,12 @@ RUN cp config/application.yml.sample config/application.yml && \
 RUN RAILS_ENV=staging SECRET_KEY_BASE=dummy_for_assets \
     ACTION_MAILER_DEFAULT_HOST=dummy.host \
     ACTION_MAILER_DEFAULT_FROM=dummy@example.com \
+=======
+RUN cp config/application.yml.sample config/application.yml
+
+# Precompile assets
+RUN RAILS_ENV=staging SECRET_KEY_BASE=dummy_for_assets \
+>>>>>>> 66ecb148c (updated dockerfile staging)
     bundle exec rails assets:precompile && \
     echo "Assets precompiled successfully for staging" && \
     ls -la public/assets/ | head -20

--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -58,7 +58,6 @@ RUN gem install bundler && \
 COPY . .
 
 # Copy sample config for asset precompilation (real values come from env at runtime)
-<<<<<<< HEAD
 RUN cp config/application.yml.sample config/application.yml && \
     cp config/database.yml.sample config/database.yml
 
@@ -66,12 +65,6 @@ RUN cp config/application.yml.sample config/application.yml && \
 RUN RAILS_ENV=staging SECRET_KEY_BASE=dummy_for_assets \
     ACTION_MAILER_DEFAULT_HOST=dummy.host \
     ACTION_MAILER_DEFAULT_FROM=dummy@example.com \
-=======
-RUN cp config/application.yml.sample config/application.yml
-
-# Precompile assets
-RUN RAILS_ENV=staging SECRET_KEY_BASE=dummy_for_assets \
->>>>>>> 66ecb148c (updated dockerfile staging)
     bundle exec rails assets:precompile && \
     echo "Assets precompiled successfully for staging" && \
     ls -la public/assets/ | head -20

--- a/app/controllers/repp/v1/accounts_controller.rb
+++ b/app/controllers/repp/v1/accounts_controller.rb
@@ -38,6 +38,7 @@ module Repp
                             api_users: serialized_users(current_user.api_users),
                             white_ips: serialized_ips(registrar.white_ips),
                             balance_auto_reload: type,
+                            accept_pdf_invoices: registrar.accept_pdf_invoices,
                             min_deposit: Setting.minimum_deposit },
                  roles: ApiUser::ROLES,
                  interfaces: WhiteIp::INTERFACES }
@@ -117,7 +118,7 @@ module Repp
       private
 
       def account_params
-        params.require(:account).permit(:billing_email, :iban, :new_user_id)
+        params.require(:account).permit(:billing_email, :iban, :new_user_id, :accept_pdf_invoices)
       end
 
       def index_params

--- a/app/models/contact/company_register.rb
+++ b/app/models/contact/company_register.rb
@@ -14,7 +14,7 @@ module Contact::CompanyRegister
   end
 
   def return_company_data
-    return unless org?
+    return unless is_contact_estonian_org?
 
     company_register.simple_data(registration_number: ident.to_s)
   rescue CompanyRegister::NotAvailableError
@@ -25,7 +25,7 @@ module Contact::CompanyRegister
   end
 
   def return_company_details
-    return unless org?
+    return unless is_contact_estonian_org?
 
     company_register.company_details(registration_number: ident.to_s)
   rescue CompanyRegister::SOAPFaultError => e
@@ -33,6 +33,28 @@ module Contact::CompanyRegister
     raise e
   rescue CompanyRegister::NotAvailableError
     []
+  end
+
+  def e_invoice_recipients
+    return unless is_contact_estonian_org?
+
+    company_register.e_invoice_recipients(registration_numbers: ident.to_s)
+  rescue CompanyRegister::SOAPFaultError => e
+    Rails.logger.error("SOAP Fault getting company details for #{ident}: #{e.message}")
+    raise e
+  rescue CompanyRegister::NotAvailableError
+    []
+  end
+
+  def org_contact_accept_e_invoice?
+    return unless is_contact_estonian_org?
+
+    result = e_invoice_recipients.first
+    result.status == 'OK'
+  end
+
+  def is_contact_estonian_org?
+    org? && country_code == 'EE'
   end
 
   def company_register

--- a/app/models/contact/company_register.rb
+++ b/app/models/contact/company_register.rb
@@ -54,7 +54,7 @@ module Contact::CompanyRegister
   end
 
   def is_contact_estonian_org?
-    org? && country_code == 'EE'
+    org? && ident_country_code == 'EE'
   end
 
   def company_register

--- a/app/models/registrar.rb
+++ b/app/models/registrar.rb
@@ -151,7 +151,7 @@ class Registrar < ApplicationRecord # rubocop:disable Metrics/ClassLength
       ]
     )
 
-    unless payable
+    unless payable && (accepts_e_invoices? && !accept_pdf_invoices?)
       InvoiceMailer.invoice_email(invoice: invoice, recipient: billing_email, paid: !payable)
                    .deliver_later(wait: 1.minute)
     end
@@ -311,6 +311,20 @@ class Registrar < ApplicationRecord # rubocop:disable Metrics/ClassLength
     return contact_email if self[:billing_email].blank?
 
     self[:billing_email]
+  end
+
+  def accepts_e_invoices?
+    return false unless address_country_code == 'EE'
+
+    result = company_register.e_invoice_recipients(registration_numbers: reg_no).first
+    result.status == 'OK'
+  rescue CompanyRegister::NotAvailableError, CompanyRegister::SOAPFaultError => e
+    Rails.logger.error("Error checking e-invoice status for #{reg_no}: #{e.message}")
+    false
+  end
+
+  def company_register
+    @company_register ||= CompanyRegister::Client.new
   end
 
   private

--- a/db/migrate/20251230104312_accept_pdf_invoices.rb
+++ b/db/migrate/20251230104312_accept_pdf_invoices.rb
@@ -1,0 +1,5 @@
+class AcceptPdfInvoices < ActiveRecord::Migration[6.1]
+  def change
+    add_column :registrars, :accept_pdf_invoices, :boolean, default: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,5 +1,6 @@
 \restrict OgpBVS4LcDZVV6fZTwmnzAAWL70pwHISsUhjW2gqrf2CNdzHNtVCcfzYehS3JFu
 
+
 -- Dumped from database version 13.4 (Debian 13.4-4.pgdg110+1)
 -- Dumped by pg_dump version 13.22 (Debian 13.22-0+deb11u1)
 
@@ -5808,6 +5809,3 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260406125446'),
 ('20251230104312'),
 ('20260220111500');
-
-
-

--- a/lib/tasks/disclose_phone_numbers.rake
+++ b/lib/tasks/disclose_phone_numbers.rake
@@ -1,0 +1,45 @@
+# rake disclose_phone_numbers:disclose
+
+namespace :disclose_phone_numbers do
+  desc 'Disclose phone numbers'
+  task disclose: :environment do
+    reg_numbers = %w[
+      10597973
+      10890199
+      10096260
+      10784403
+      10641728
+      10762679
+      10557933
+      12659649
+      12176224
+      90010019
+      10960801
+      16406158
+      10510593
+      70000740
+      10838419
+      11099473
+      451394720
+      10647754
+      10176042
+      14127885
+      11163283
+      11685113
+      14281238
+      10098106
+      10577829
+      10234957
+      12345678
+      11072764
+      11100236
+    ]
+
+    reg_numbers.each do |reg_no|
+      registrar = Registrar.find_by(reg_no: reg_no)
+      registrar.update!(accept_pdf_invoices: false)
+
+      Rails.logger.info("For registrar with name #{registrar.name} and reg no #{registrar.reg_no} set accept_pdf_invoices to false")
+    end
+  end
+end

--- a/test/models/contact/company_register_test.rb
+++ b/test/models/contact/company_register_test.rb
@@ -5,6 +5,8 @@ Company = Struct.new(:registration_number, :company_name, :status)
 class CompanyRegisterTest < ActiveSupport::TestCase
   def setup
     @acme_ltd = contacts(:acme_ltd)
+    @acme_ltd.update!(ident_country_code: 'EE', ident_type: 'org', ident: '12345678')
+
     @john = contacts(:john)
     @company_register_stub = CompanyRegister::Client.new
   end

--- a/test/models/registrar/invoice_email_cancellation_test.rb
+++ b/test/models/registrar/invoice_email_cancellation_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+
+class RegistrarInvoiceEmailCancellationTest < ActiveJob::TestCase
+  setup do
+    @registrar = registrars(:bestnames)
+    @registrar.update!(address_country_code: 'EE', reference_no: '1232', vat_rate: 24)
+    @invoice_params = 100
+
+    stub_request(:post, "https://eis_billing_system:3000/api/v1/invoice_generator/invoice_number_generator").
+      to_return(status: 200, body: "{\"invoice_number\":\"123456\"}", headers: {})
+
+    stub_request(:post, "https://eis_billing_system:3000/api/v1/invoice_generator/invoice_generator").
+      to_return(status: 200, body: "{\"everypay_link\":\"http://link.test\"}", headers: {})
+
+    stub_request(:put, "https://registry:3000/eis_billing/e_invoice_response").
+      to_return(status: 200, body: "{\"invoice_number\":\"123456\"}, {\"date\":\"#{Time.zone.now}\"}", headers: {})
+
+    stub_request(:post, "https://eis_billing_system:3000/api/v1/e_invoice/e_invoice").
+      to_return(status: 200, body: "", headers: {})
+  end
+
+  def test_sends_email_when_registrar_does_not_accept_e_invoices_and_pdf_opt_in_is_true
+    # Name does not contain 'einvoice', so stub returns 'MR' (not OK)
+    @registrar.update!(name: 'simple-registrar', accept_pdf_invoices: true)
+
+    assert_enqueued_jobs 1, only: ActionMailer::MailDeliveryJob do
+      @registrar.issue_prepayment_invoice(@invoice_params)
+    end
+  end
+
+  def test_sends_email_when_registrar_does_not_accept_e_invoices_and_pdf_opt_in_is_false
+    # Name does not contain 'einvoice', so stub returns 'MR' (not OK)
+    @registrar.update!(name: 'simple-registrar', accept_pdf_invoices: false)
+
+    assert_enqueued_jobs 1, only: ActionMailer::MailDeliveryJob do
+      @registrar.issue_prepayment_invoice(@invoice_params)
+    end
+  end
+
+  def test_skips_email_when_registrar_accepts_e_invoices_and_pdf_opt_in_is_false
+    @registrar.update!(name: 'einvoice-registrar', accept_pdf_invoices: false)
+
+    assert_enqueued_jobs 0, only: ActionMailer::MailDeliveryJob do
+      @registrar.issue_prepayment_invoice(@invoice_params)
+    end
+  end
+
+  def test_sends_email_when_registrar_accepts_e_invoices_BUT_pdf_opt_in_is_true
+    @registrar.update!(name: 'einvoice-registrar', accept_pdf_invoices: true)
+
+    assert_enqueued_jobs 1, only: ActionMailer::MailDeliveryJob do
+      @registrar.issue_prepayment_invoice(@invoice_params)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,6 +46,15 @@ class CompanyRegisterClientStub
   def company_details(registration_number:)
     []
   end
+
+  def e_invoice_recipients(registration_numbers:)
+    if ::Registrar.exists?(reg_no: registration_numbers)
+      registrar = ::Registrar.find_by(reg_no: registration_numbers)
+      status = registrar.name.include?('einvoice') ? 'OK' : 'MR'
+      return [Struct.new(:status).new(status)]
+    end
+    [Struct.new(:status).new('OK')]
+  end
 end
 
 CompanyRegister::Client = CompanyRegisterClientStub


### PR DESCRIPTION
Allow registrars who accept e-invoices to opt out of receiving additional PDF invoice emails. This reduces duplicate work when e-invoices are already processed directly by accounting.
- Add  column to registrars table (default: true)
- Check e-invoice recipient status from Estonian Business Registry
- Skip PDF email when registrar accepts e-invoices AND opts out
- Expose setting via REPP API (GET details / PUT update) Closes #2881