### PR TITLE
Send poll message to registrar when pending registrant change or delete request expires

### DIFF
--- a/app/interactions/domains/expired_pendings/process_clean.rb
+++ b/app/interactions/domains/expired_pendings/process_clean.rb
@@ -20,10 +20,12 @@ module Domains
                                        registrant: domain.registrant,
                                        send_to: [domain.new_registrant_email,
                                                  domain.registrant.email]).deliver_later
+        domain.notify_registrar(:poll_pending_update_expired_by_registrant)
       end
 
       def notify_pending_delete
         DomainDeleteMailer.expired(domain).deliver_later
+        domain.notify_registrar(:poll_pending_delete_expired_by_registrant)
       end
 
       def clean_pendings

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -651,6 +651,8 @@ en:
   poll_pending_update_rejected_by_registrant: 'Registrant rejected domain update'
   poll_pending_delete_rejected_by_registrant: 'Registrant rejected domain deletion'
   poll_pending_delete_confirmed_by_registrant: 'Registrant confirmed domain deletion'
+  poll_pending_update_expired_by_registrant: 'Registrant did not confirm domain update'
+  poll_pending_delete_expired_by_registrant: 'Registrant did not confirm domain deletion'
   manage: Manage
   pending_epp: Pending epp
   id: ID

--- a/test/interactions/domains/expired_pendings/process_clean_test.rb
+++ b/test/interactions/domains/expired_pendings/process_clean_test.rb
@@ -1,0 +1,90 @@
+require 'test_helper'
+
+module Domains
+  module ExpiredPendings
+    class ProcessCleanTest < ActiveSupport::TestCase
+      include ActionMailer::TestHelper
+
+      setup do
+        @domain = domains(:shop)
+        @domain.update!(registrant_verification_asked_at: Time.zone.now,
+                        registrant_verification_token: 'test')
+        ActionMailer::Base.deliveries.clear
+      end
+
+      def test_notifies_registrar_when_pending_update_expires
+        @domain.statuses = [DomainStatus::PENDING_UPDATE]
+        @domain.save(validate: false)
+
+        assert_difference '@domain.registrar.notifications.count', 1 do
+          perform_enqueued_jobs do
+            ProcessClean.run!(domain: @domain)
+          end
+        end
+
+        notification = @domain.registrar.notifications.last
+        assert_equal "Registrant did not confirm domain update: #{@domain.name}",
+                     notification.text
+        assert_equal @domain.id, notification.attached_obj_id
+        assert_equal 'Domain', notification.attached_obj_type
+      end
+
+      def test_notifies_registrar_when_pending_delete_confirmation_expires
+        @domain.statuses = [DomainStatus::PENDING_DELETE_CONFIRMATION]
+        @domain.save(validate: false)
+
+        assert_difference '@domain.registrar.notifications.count', 1 do
+          perform_enqueued_jobs do
+            ProcessClean.run!(domain: @domain)
+          end
+        end
+
+        notification = @domain.registrar.notifications.last
+        assert_equal "Registrant did not confirm domain deletion: #{@domain.name}",
+                     notification.text
+        assert_equal @domain.id, notification.attached_obj_id
+        assert_equal 'Domain', notification.attached_obj_type
+      end
+
+      def test_notifies_registrar_when_pending_delete_expires
+        @domain.statuses = [DomainStatus::PENDING_DELETE]
+        @domain.save(validate: false)
+
+        assert_difference '@domain.registrar.notifications.count', 1 do
+          perform_enqueued_jobs do
+            ProcessClean.run!(domain: @domain)
+          end
+        end
+
+        notification = @domain.registrar.notifications.last
+        assert_equal "Registrant did not confirm domain deletion: #{@domain.name}",
+                     notification.text
+      end
+
+      def test_still_sends_expired_email_on_pending_delete_confirmation
+        @domain.statuses = [DomainStatus::PENDING_DELETE_CONFIRMATION]
+        @domain.save(validate: false)
+
+        perform_enqueued_jobs do
+          ProcessClean.run!(domain: @domain)
+        end
+
+        assert_emails 1
+      end
+
+      def test_clears_pending_statuses_and_verification_data
+        @domain.statuses = [DomainStatus::PENDING_UPDATE]
+        @domain.save(validate: false)
+
+        perform_enqueued_jobs do
+          ProcessClean.run!(domain: @domain)
+        end
+
+        @domain.reload
+        assert_not @domain.pending_update?
+        assert_nil @domain.registrant_verification_token
+        assert_nil @domain.registrant_verification_asked_at
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously only an email notification was sent to the registrant when a pending update or pending delete confirmation expired. Registrars had to guess whether the pending operation was still active or had already expired.

Add poll messages so registrars are notified through EPP as well:
- "Registrant did not confirm domain update" when pendingUpdate expires
- "Registrant did not confirm domain deletion" when pendingDelete/pendingDeleteConfirmation expires

Closes #2924