### PR TITLE
Handle missing contacts in contact update action serialization

### DIFF
--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -29,16 +29,21 @@ class Action < ApplicationRecord
   end
 
   def to_non_available_contact_codes
-    return [serialized_contact(contact)] unless bulk_action?
+    return subaction_contact_codes if bulk_action?
 
-    subactions.map do |a|
-      serialized_contact(a.contact)
-    end
+    contact_code = serialized_contact(contact)
+    contact_code ? [contact_code] : []
   end
 
   private
 
+  def subaction_contact_codes
+    subactions.filter_map { |a| serialized_contact(a.contact) }
+  end
+
   def serialized_contact(contact)
+    return unless contact
+
     {
       code: contact.code,
       avail: 0,

--- a/test/integration/repp/v1/registrar/summary_test.rb
+++ b/test/integration/repp/v1/registrar/summary_test.rb
@@ -58,4 +58,22 @@ class ReppV1RegistrarSummaryTest < ActionDispatch::IntegrationTest
     ENV["shunter_default_threshold"] = '10000'
     ENV["shunter_enabled"] = 'false'
   end
+
+  def test_handles_contact_update_notification_with_missing_contact
+    action = actions(:contact_update)
+    action.update!(contact: nil)
+    notifications(:complete).update!(
+      action: action,
+      attached_obj_type: 'ContactUpdateAction',
+      attached_obj_id: action.id,
+      text: 'Contact update notification'
+    )
+
+    get '/repp/v1/registrar/summary', headers: @auth_headers
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    assert_response :ok
+    assert_equal 1000, json[:code]
+    assert_equal [], json[:data][:notification][:attached_obj_data][:contacts]
+  end
 end

--- a/test/models/action_test.rb
+++ b/test/models/action_test.rb
@@ -17,4 +17,24 @@ class ActionTest < ActiveSupport::TestCase
   def test_notification_key_for_contact
     assert_equal :contact_update, @action.notification_key
   end
+
+  def test_to_non_available_contact_codes
+    assert_equal [{ code: @action.contact.code, avail: 0, reason: 'in use' }],
+                 @action.to_non_available_contact_codes
+  end
+
+  def test_to_non_available_contact_codes_with_missing_contact
+    @action.update!(contact: nil)
+
+    assert_equal [], @action.to_non_available_contact_codes
+  end
+
+  def test_to_non_available_contact_codes_for_bulk_action_with_missing_subaction_contact
+    bulk_action = actions(:contacts_update_bulk_action)
+    actions(:contact_update_subaction_one).update!(contact: nil)
+
+    codes = bulk_action.to_non_available_contact_codes
+    assert_equal 1, codes.size
+    assert_equal actions(:contact_update_subaction_two).contact.code, codes.first[:code]
+  end
 end


### PR DESCRIPTION
## Summary
- Fix `NoMethodError (undefined method 'code' for nil:NilClass)` in `Action#serialized_contact` when serializing contact update notifications
- Wavecom (and potentially other registrars) could not access the registrar portal — `/repp/v1/registrar/summary` returned 500, causing a redirect loop (`too_many_redirects`) in the frontend
- Root cause: an unread `ContactUpdateAction` notification where the action or one of its bulk subactions had a nil `contact` (likely from a registrant auto-update where contact save failed or contact was removed)
- `Action#to_non_available_contact_codes` now skips nil contacts instead of crashing; affected endpoints return an empty contacts list for the broken entries