### PR TITLE
Allowed unverified users without subject to sign in

### DIFF
--- a/app/controllers/repp/v1/base_controller.rb
+++ b/app/controllers/repp/v1/base_controller.rb
@@ -98,7 +98,7 @@ module Repp
       end
 
       def authentication_failure_message
-        if @current_user&.active? && !@current_user.identity_verified?
+        if @current_user&.active? && @current_user.subject.present? && !@current_user.identity_verified?
           I18n.t('registrar.authorization.identity_not_verified')
         else
           I18n.t('registrar.authorization.invalid_authorization_information')

--- a/app/models/api_user.rb
+++ b/app/models/api_user.rb
@@ -39,7 +39,7 @@ class ApiUser < User
   after_commit :notify_registrar_subject_changed, on: :update
 
   scope :eligible_for_sign_in, lambda {
-    where(active: true).where.not(verified_at: nil)
+    where(active: true).where('subject IS NULL OR subject = ? OR verified_at IS NOT NULL', '')
   }
 
   def identity_verified?
@@ -47,7 +47,7 @@ class ApiUser < User
   end
 
   def eligible_for_sign_in?
-    active? && identity_verified?
+    active? && (subject.blank? || identity_verified?)
   end
 
   def verification_pending?

--- a/test/integration/repp/v1/registrar/auth/check_info_test.rb
+++ b/test/integration/repp/v1/registrar/auth/check_info_test.rb
@@ -39,8 +39,8 @@ class ReppV1RegistrarAuthCheckInfoTest < ActionDispatch::IntegrationTest
     assert_equal json[:message], 'Invalid authorization information'
   end
 
-  def test_rejects_unverified_user_login_with_valid_password
-    @user.update_columns(verified_at: nil)
+  def test_rejects_unverified_user_login_with_valid_password_when_subject_present
+    @user.update_columns(subject: 'EE1234', verified_at: nil)
 
     get '/repp/v1/registrar/auth', headers: @auth_headers
     json = JSON.parse(response.body, symbolize_names: true)
@@ -48,6 +48,16 @@ class ReppV1RegistrarAuthCheckInfoTest < ActionDispatch::IntegrationTest
     assert_response :unauthorized
     assert_equal I18n.t('registrar.authorization.identity_not_verified'), json[:message]
     assert_equal false, json[:data][:eligible_for_sign_in]
+  end
+
+  def test_allows_unverified_user_login_without_subject
+    @user.update_columns(subject: nil, verified_at: nil)
+
+    get '/repp/v1/registrar/auth', headers: @auth_headers
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    assert_response :ok
+    assert_equal json[:data][:username], @user.username
   end
 
   def test_returns_error_response_if_throttled

--- a/test/models/api_user_test.rb
+++ b/test/models/api_user_test.rb
@@ -159,7 +159,7 @@ class ApiUserTest < ActiveSupport::TestCase
     assert_not @user.linked_with?(nil)
   end
 
-  def test_eligible_for_sign_in_requires_active_and_verified
+  def test_eligible_for_sign_in_requires_active_and_verified_when_subject_present
     @user.update_columns(active: true, verified_at: Time.zone.now)
     assert @user.eligible_for_sign_in?
 
@@ -168,6 +168,11 @@ class ApiUserTest < ActiveSupport::TestCase
 
     @user.update_columns(active: true, subject: 'EE1234', verified_at: nil)
     assert_not @user.eligible_for_sign_in?
+  end
+
+  def test_eligible_for_sign_in_allows_unverified_user_without_subject
+    @user.update_columns(active: true, subject: nil, verified_at: nil)
+    assert @user.eligible_for_sign_in?
   end
 
   def test_subject_change_clears_verification_status_when_subject_previously_present


### PR DESCRIPTION
Relax REPP API sign-in rules so identity verification is required only for API users who have a subject. Users without a subject can authenticate with valid credentials while still active, without needing verified_at set.

Updated Repp::V1::BaseController#authentication_failure_message so the identity_not_verified message is returned only when the user is active, has a subject, and is not verified. Other auth failures continue to return invalid_authorization_information.
