### PR TITLE
Return REPP code 1001 for pending domain update and delete responses

### DIFF
--- a/app/controllers/repp/v1/base_controller.rb
+++ b/app/controllers/repp/v1/base_controller.rb
@@ -42,6 +42,21 @@ module Repp
         render(json: @response, status: :ok)
       end
 
+      def render_action_pending_success(data: nil)
+        render_success(
+          code: Epp::Response::Result::Code.codes[:completed_successfully_action_pending],
+          message: Epp::Response::Result::Code.default_descriptions[1001],
+          data: data
+        )
+      end
+
+      def render_domain_command_success(pending:)
+        data = { domain: { name: @domain.name } }
+        return render_action_pending_success(data: data) if pending
+
+        render_success(data: data)
+      end
+
       def epp_errors
         @epp_errors ||= ActiveModel::Errors.new(self)
       end

--- a/app/controllers/repp/v1/domains_controller.rb
+++ b/app/controllers/repp/v1/domains_controller.rb
@@ -104,7 +104,7 @@ module Repp
           return
         end
 
-        render_success(data: { domain: { name: @domain.name } })
+        render_domain_command_success(pending: @domain.epp_pending_update.present?)
       end
 
       api :GET, '/repp/v1/domains/:domain_name/transfer_info'
@@ -153,7 +153,7 @@ module Repp
         handle_errors(@domain) and return unless action.call
         # rubocop:enable Style/AndOr
 
-        render_success(data: { domain: { name: @domain.name } })
+        render_domain_command_success(pending: @domain.epp_pending_delete.present?)
       end
 
       private

--- a/test/integration/repp/v1/domains/delete_test.rb
+++ b/test/integration/repp/v1/domains/delete_test.rb
@@ -26,8 +26,8 @@ class ReppV1DomainsDeleteTest < ActionDispatch::IntegrationTest
     @domain.reload
     json = JSON.parse(response.body, symbolize_names: true)
     assert_response :ok
-    assert_equal 1000, json[:code]
-    assert_equal 'Command completed successfully', json[:message]
+    assert_equal 1001, json[:code]
+    assert_equal Epp::Response::Result::Code.default_descriptions[1001], json[:message]
 
     assert @domain.statuses.include? DomainStatus::PENDING_DELETE_CONFIRMATION
     assert_not @domain.statuses.include? DomainStatus::PENDING_DELETE

--- a/test/integration/repp/v1/domains/update_test.rb
+++ b/test/integration/repp/v1/domains/update_test.rb
@@ -22,7 +22,7 @@ class ReppV1DomainsUpdateTest < ActionDispatch::IntegrationTest
 
     json = update_domain(registrant: { code: new_registrant.code })
 
-    assert_repp_success(json)
+    assert_repp_action_pending(json)
     refute_equal new_registrant.code, @domain.registrant.code
     assert_includes @domain.statuses, DomainStatus::PENDING_UPDATE
   end
@@ -200,6 +200,12 @@ class ReppV1DomainsUpdateTest < ActionDispatch::IntegrationTest
   def assert_repp_success(json)
     assert_response :ok
     assert_equal 1000, json[:code]
+  end
+
+  def assert_repp_action_pending(json)
+    assert_response :ok
+    assert_equal 1001, json[:code]
+    assert_equal Epp::Response::Result::Code.default_descriptions[1001], json[:message]
   end
 
   def assert_repp_error(json, http_status:, code:, message:)


### PR DESCRIPTION
close #2940

REPP pending action returns 1001 as response code on domain update and delete request if 'pending' status is set.
Similar to EPP request.