### PR TITLE
initial

### DIFF
--- a/app/controllers/repp/v1/base_controller.rb
+++ b/app/controllers/repp/v1/base_controller.rb
@@ -21,13 +21,7 @@ module Repp
       private
 
       def set_domain
-        registrar = current_user.registrar
-        @domain = Epp::Domain.find_by(registrar: registrar, name: params[:domain_id])
-        @domain ||= Epp::Domain.find_by!(registrar: registrar, name_puny: params[:domain_id])
-
-        return @domain if @domain
-
-        raise ActiveRecord::RecordNotFound
+        @domain = Epp::Domain.find_repp_by_name!(params[:domain_id], registrar: current_user.registrar)
       end
 
       def set_paper_trail_whodunnit

--- a/app/controllers/repp/v1/domains/renews_controller.rb
+++ b/app/controllers/repp/v1/domains/renews_controller.rb
@@ -79,7 +79,7 @@ module Repp
           domains = []
           if bulk_renew_params[:domains].instance_of?(Array)
             bulk_renew_params[:domains].each do |idn|
-              domain = Epp::Domain.find_by(name: idn)
+              domain = Epp::Domain.find_repp_by_name(idn)
               domains << domain if domain
               next if domain
 

--- a/app/controllers/repp/v1/domains/transfers_controller.rb
+++ b/app/controllers/repp/v1/domains/transfers_controller.rb
@@ -28,9 +28,11 @@ module Repp
 
         def set_domain
           domain_id = transfer_params[:domain_id]
-          h = {}
-          h[domain_id.match?(/\A[0-9]+\z/) ? :id : :name] = domain_id
-          @domain = Epp::Domain.find_by!(h)
+          @domain = if domain_id.match?(/\A[0-9]+\z/)
+                      Epp::Domain.find(domain_id)
+                    else
+                      Epp::Domain.find_repp_by_name!(domain_id)
+                    end
         end
 
         def transfer_params

--- a/app/controllers/repp/v1/domains_controller.rb
+++ b/app/controllers/repp/v1/domains_controller.rb
@@ -33,7 +33,7 @@ module Repp
       api :GET, '/repp/v1/domains/:domain_name'
       desc 'Get a specific domain'
       def show
-        @domain = Epp::Domain.find_by(name: params[:id])
+        @domain = Epp::Domain.find_repp_by_name(params[:id])
         authorize! :info, @domain
 
         sponsor = @domain.registrar == current_user.registrar
@@ -166,7 +166,8 @@ module Repp
       end
 
       def initiate_transfer(transfer)
-        domain = Epp::Domain.find_or_initialize_by(name: transfer[:domain_name])
+        domain = Epp::Domain.find_repp_by_name(transfer[:domain_name])
+        domain ||= Epp::Domain.new(name: transfer[:domain_name])
         action = Actions::DomainTransfer.new(domain, transfer[:transfer_code],
                                              current_user.registrar)
 
@@ -195,14 +196,7 @@ module Repp
       end
 
       def set_domain
-        registrar = current_user.registrar
-
-        @domain = Epp::Domain.find_by(registrar: registrar, name: params[:id])
-        @domain ||= Epp::Domain.find_by!(registrar: registrar, name_puny: params[:id])
-
-        return @domain if @domain
-
-        raise ActiveRecord::RecordNotFound
+        @domain = Epp::Domain.find_repp_by_name!(params[:id], registrar: current_user.registrar)
       end
 
       def find_password
@@ -228,7 +222,7 @@ module Repp
         entry = params[:id]
         return Epp::Domain.find(entry) if entry.match?(/\A[0-9]+\z/)
 
-        Epp::Domain.find_by!('name = ? OR name_puny = ?', entry, entry)
+        Epp::Domain.find_repp_by_name!(entry)
       end
 
       def limit

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -388,6 +388,22 @@ class Domain < ApplicationRecord
     domain
   end
 
+  def self.normalize_repp_domain_name(name)
+    name.to_s.strip.downcase.presence
+  end
+
+  def self.find_repp_by_name(name, registrar: nil)
+    normalized = normalize_repp_domain_name(name)
+    return nil unless normalized
+
+    relation = registrar ? where(registrar: registrar) : all
+    relation.find_by_idn(normalized) || relation.find_by(name_puny: normalized)
+  end
+
+  def self.find_repp_by_name!(name, registrar: nil)
+    find_repp_by_name(name, registrar: registrar) || raise(ActiveRecord::RecordNotFound)
+  end
+
   def puny_label
     name_puny.to_s.split('.').first
   end

--- a/test/integration/api/domain_transfers_test.rb
+++ b/test/integration/api/domain_transfers_test.rb
@@ -80,10 +80,24 @@ class APIDomainTransfersTest < ApplicationIntegrationTest
                 JSON.parse(response.body, symbolize_names: true)
   end
 
+  def test_bulk_transfer_with_uppercase_domain_name
+    post '/repp/v1/domains/transfer', params: uppercase_request_params, as: :json,
+         headers: { 'HTTP_AUTHORIZATION' => http_auth_key }
+
+    assert_response :ok
+    json = JSON.parse(response.body, symbolize_names: true)
+    assert_equal 'shop.test', json[:data][:success][0][:domain_name]
+    assert_equal @new_registrar, @domain.reload.registrar
+  end
+
   private
 
   def request_params
     { data: { domain_transfers: [{ domain_name: 'shop.test', transfer_code: '65078d5' }] } }
+  end
+
+  def uppercase_request_params
+    { data: { domain_transfers: [{ domain_name: 'SHOP.TEST', transfer_code: '65078d5' }] } }
   end
 
   def http_auth_key

--- a/test/integration/repp/v1/domains/bulk_renew_test.rb
+++ b/test/integration/repp/v1/domains/bulk_renew_test.rb
@@ -40,6 +40,26 @@ class ReppV1DomainsBulkRenewTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_renews_domains_with_uppercase_names
+    payload = {
+      "domains": [
+        'SHOP.TEST',
+        'AIRPORT.TEST',
+        'LIBRARY.TEST'
+      ],
+      "renew_period": "1y"
+    }
+
+    post "/repp/v1/domains/renew/bulk", headers: @auth_headers, params: payload
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    assert_response :ok
+    assert_equal 1000, json[:code]
+    assert json[:data][:updated_domains].include? 'shop.test'
+    assert json[:data][:updated_domains].include? 'airport.test'
+    assert json[:data][:updated_domains].include? 'library.test'
+  end
+
   def test_keeps_update_prohibited_status
     domain = domains(:shop)
     domain.update(statuses: [DomainStatus::CLIENT_UPDATE_PROHIBITED, DomainStatus::SERVER_UPDATE_PROHIBITED])

--- a/test/integration/repp/v1/domains/dnssec_test.rb
+++ b/test/integration/repp/v1/domains/dnssec_test.rb
@@ -39,6 +39,15 @@ class ReppV1DomainsDnssecTest < ActionDispatch::IntegrationTest
     assert_equal 1, json[:data][:dns_keys].length
   end
 
+  def test_shows_dnssec_keys_with_uppercase_domain_name
+    get "/repp/v1/domains/#{@domain.name.upcase}/dnssec", headers: @auth_headers
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    assert_response :ok
+    assert_equal 1000, json[:code]
+    assert_empty json[:data][:dns_keys]
+  end
+
   def test_creates_dnssec_key_successfully
     assert @domain.dnskeys.empty?
     payload = {

--- a/test/integration/repp/v1/domains/list_test.rb
+++ b/test/integration/repp/v1/domains/list_test.rb
@@ -68,6 +68,18 @@ class ReppV1DomainsListTest < ActionDispatch::IntegrationTest
     assert_equal serialized_domain.as_json, json[:data][:domain].as_json
   end
 
+  def test_returns_specific_domain_details_by_uppercase_name
+    domain = domains(:shop)
+    get "/repp/v1/domains/#{domain.name.upcase}", headers: @auth_headers
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    assert_response :ok
+    assert_equal 1000, json[:code]
+
+    serialized_domain = Serializers::Repp::Domain.new(domain).to_json
+    assert_equal serialized_domain.as_json, json[:data][:domain].as_json
+  end
+
   def test_returns_detailed_registrar_domains_by_search_query
     search_params = {
       name_matches: '%library%',

--- a/test/integration/repp/v1/domains/transfer_info_test.rb
+++ b/test/integration/repp/v1/domains/transfer_info_test.rb
@@ -28,6 +28,18 @@ class ReppV1DomainsTransferInfoTest < ActionDispatch::IntegrationTest
     assert json[:data][:tech_contacts].present?
   end
 
+  def test_can_query_domain_info_with_uppercase_name
+    headers = @auth_headers
+    headers['Auth-Code'] = @domain.transfer_code
+
+    get "/repp/v1/domains/#{@domain.name.upcase}/transfer_info", headers: headers
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    assert_response :ok
+    assert_equal 1000, json[:code]
+    assert_equal @domain.name, json[:data][:domain]
+  end
+
   def test_respects_domain_authorization_code
     headers = @auth_headers
     headers['Auth-Code'] = 'jhfgifhdg'

--- a/test/integration/repp/v1/domains/transfer_test.rb
+++ b/test/integration/repp/v1/domains/transfer_test.rb
@@ -63,6 +63,38 @@ class ReppV1DomainsTransferTest < ActionDispatch::IntegrationTest
     assert @domain.registrar = @user.registrar
   end
 
+  def test_transfers_domain_with_uppercase_name
+    payload = {
+      "data": {
+        "domain_transfers": [
+          { "domain_name": @domain.name.upcase, "transfer_code": @domain.transfer_code }
+        ]
+      }
+    }
+    post "/repp/v1/domains/transfer", headers: @auth_headers, params: payload
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    assert_response :ok
+    assert_equal 1000, json[:code]
+    assert_equal @domain.name, json[:data][:success][0][:domain_name]
+
+    @domain.reload
+
+    assert_equal @user.registrar, @domain.registrar
+  end
+
+  def test_transfers_scoped_domain_with_uppercase_name
+    refute @domain.registrar == @user.registrar
+    payload = { transfer: { transfer_code: @domain.transfer_code } }
+    post "/repp/v1/domains/#{@domain.name.upcase}/transfer", headers: @auth_headers, params: payload
+    json = JSON.parse(response.body, symbolize_names: true)
+    @domain.reload
+
+    assert_response :ok
+    assert_equal 1000, json[:code]
+    assert_equal @user.registrar, @domain.registrar
+  end
+
   def test_does_not_transfer_domain_if_not_transferable
     @domain.schedule_force_delete(type: :fast_track)
 

--- a/test/models/domain_test.rb
+++ b/test/models/domain_test.rb
@@ -373,6 +373,31 @@ class DomainTest < ActiveSupport::TestCase
     assert_equal unnormalized_name, domain.name_dirty
   end
 
+  def test_find_repp_by_name_normalizes_uppercase_and_whitespace
+    domain = domains(:shop)
+
+    assert_equal domain, Domain.find_repp_by_name('SHOP.TEST')
+    assert_equal domain, Domain.find_repp_by_name(' shop.test ')
+  end
+
+  def test_find_repp_by_name_finds_by_punycode
+    domain = domains(:shop)
+    domain.update!(name_puny: 'xn--prototp-s2aa.ee')
+
+    assert_equal domain, Domain.find_repp_by_name('XN--PROTOTP-S2AA.EE')
+  end
+
+  def test_find_repp_by_name_scopes_by_registrar
+    domain = domains(:shop)
+
+    assert_equal domain, Domain.find_repp_by_name('SHOP.TEST', registrar: domain.registrar)
+    assert_nil Domain.find_repp_by_name('SHOP.TEST', registrar: registrars(:goodnames))
+  end
+
+  def test_find_repp_by_name_returns_nil_when_missing
+    assert_nil Domain.find_repp_by_name('missing.test')
+  end
+
   def test_converts_name_to_punycode
     domain = Domain.new(name: 'münchen.test')
     assert_equal 'xn--mnchen-3ya.test', domain.name_puny


### PR DESCRIPTION
close #2943

This PR makes REPP domain name lookups case-insensitive. 
Domain name normalization is centralized in the Domain model (find_repp_by_name), and all REPP domain endpoints now use it (bulk transfer, show, transfer_info, renew, nested resources, etc.). 
Fixes cases where uppercase names like EXAMPLE.EE returned 2303 "Object does not exist". 

Tests added.