### PR TITLE
Fix 500 error on contact create with invalid ident

### DIFF
--- a/app/interactions/actions/contact_create.rb
+++ b/app/interactions/actions/contact_create.rb
@@ -57,7 +57,24 @@ module Actions
       identifier = ::Contact::Ident.new(code: ident[:ident], type: ident[:ident_type],
                                         country_code: ident[:ident_country_code])
 
-      identifier.validate
+      unless identifier.valid?
+        identifier.errors.details.each do |attr, error_details|
+          error_details.each do |error_detail|
+            ::Contact::Ident.epp_code_map.each do |epp_code, attr_to_error|
+              next unless attr_to_error.any? { |i| i == [attr, error_detail[:error]] }
+
+              message = identifier.errors.generate_message(attr, error_detail[:error], error_detail)
+              message = identifier.errors.full_message(attr, message)
+              message = "#{identifier.model_name.human} #{message.camelize(:lower)}" if attr != :base
+
+              contact.add_epp_error(epp_code, nil, attr.to_s, message)
+            end
+          end
+        end
+        @error = true
+        return
+      end
+
       contact.identifier = identifier
     end
 
@@ -84,6 +101,7 @@ module Actions
     end
 
     def maybe_company_is_relevant
+      return true if @error
       return true if ENV['allow_validate_business_contacts'] && ENV['allow_validate_business_contacts'] == 'false'
       return true unless contact.org?
       return true unless contact.ident_country_code == 'EE'
@@ -91,6 +109,7 @@ module Actions
       company_status = contact.return_company_status
 
       return true if [Contact::REGISTERED, Contact::LIQUIDATED].include? company_status
+
       contact.add_epp_error('2003', nil, 'ident', I18n.t('errors.messages.company_not_registered'))
 
       @error = true
@@ -112,7 +131,7 @@ module Actions
     def maybe_validate_contact
       return if @error || !contact.valid?
 
-      [:regex, :mx].each do |m|
+      %i[regex mx].each do |m|
         contact.verify_email(check_level: m, single_email: true)
       end
     end

--- a/app/validators/contact/ident/national_id_validator.rb
+++ b/app/validators/contact/ident/national_id_validator.rb
@@ -1,22 +1,14 @@
 class Contact::Ident::NationalIdValidator < ActiveModel::EachValidator
-  def self.country_specific_validations
-    {
-      Country.new('EE') => proc { |code| Isikukood.new(code).valid? },
-    }
-  end
+  COUNTRY_SPECIFIC_VALIDATIONS = {
+    'EE' => proc { |code| Isikukood.new(code).valid? },
+  }.freeze
 
   def validate_each(record, attribute, value)
-    validation = validation_for(record.country)
+    validation = COUNTRY_SPECIFIC_VALIDATIONS[record.country_code]
 
     return unless validation
 
     valid = validation.call(value)
     record.errors.add(attribute, :invalid_national_id, country: record.country) unless valid
-  end
-
-  private
-
-  def validation_for(country)
-    self.class.country_specific_validations[country]
   end
 end

--- a/app/validators/contact/ident/reg_no_validator.rb
+++ b/app/validators/contact/ident/reg_no_validator.rb
@@ -1,22 +1,15 @@
 class Contact::Ident::RegNoValidator < ActiveModel::EachValidator
-  def self.country_specific_formats
-    {
-      Country.new('EE') => /\A[0-9]{8}\z/,
-    }
-  end
+  COUNTRY_SPECIFIC_FORMATS = {
+    'EE' => /\A[0-9]{8}\z/,
+  }.freeze
 
   def validate_each(record, attribute, value)
-    format = format_for(record.country)
+    format = COUNTRY_SPECIFIC_FORMATS[record.country_code]
 
     return unless format
 
     return if value.match?(format)
+
     record.errors.add(attribute, :invalid_reg_no, country: record.country)
-  end
-
-  private
-
-  def format_for(country)
-    self.class.country_specific_formats[country]
   end
 end

--- a/test/integration/epp/contact/create/base_test.rb
+++ b/test/integration/epp/contact/create/base_test.rb
@@ -241,6 +241,39 @@ class EppContactCreateBaseTest < EppTestCase
   #   assert_epp_response :parameter_value_syntax_error
   # end
 
+  def test_returns_error_when_org_ident_contains_country_prefix
+    request_xml = <<-XML
+      <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+      <epp xmlns="#{Xsd::Schema.filename(for_prefix: 'epp-ee', for_version: '1.0')}">
+        <command>
+          <create>
+            <contact:create xmlns:contact="#{Xsd::Schema.filename(for_prefix: 'contact-ee', for_version: '1.1')}">
+              <contact:postalInfo>
+                <contact:name>Test Org</contact:name>
+              </contact:postalInfo>
+              <contact:voice>+372.1234567</contact:voice>
+              <contact:email>org@registrar.test</contact:email>
+            </contact:create>
+          </create>
+          <extension>
+            <eis:extdata xmlns:eis="#{Xsd::Schema.filename(for_prefix: 'eis', for_version: '1.0')}">
+              <eis:ident type="org" cc="EE">EE10294687</eis:ident>
+            </eis:extdata>
+          </extension>
+        </command>
+      </epp>
+    XML
+
+    assert_no_difference 'Contact.count' do
+      post epp_create_path, params: { frame: request_xml },
+           headers: { 'HTTP_COOKIE' => 'session=api_bestnames' }
+    end
+
+    response_xml = Nokogiri::XML(response.body)
+    assert_correct_against_schema response_xml
+    assert_epp_response :parameter_value_syntax_error
+  end
+
   def test_respects_custom_code
     name = 'new'
     code = 'custom-id'


### PR DESCRIPTION
**Summary**

- Fix RegNoValidator and NationalIdValidator using Country.new('EE') as hash keys — hash lookup never matched because Country lacks eql?/hash, making both validators no-ops. Replaced with string keys and record.country_code.

- Fix maybe_validate_ident ignoring identifier.valid? result — invalid ident (e.g. EE102946871) passed through to maybe_company_is_relevant, which made a SOAP call to the Business Registry causing 'Unparseable integer' fault and EPP 2400 (Internal Server Error) instead of EPP 2005 (Parameter value syntax error).

- Add early @error flag and EPP error generation in maybe_validate_ident to short-circuit before the SOAP call.

- Add @error guard to maybe_company_is_relevant to skip the SOAP call when prior validation has already failed.
