### PR TITLE
Enable registrars to cancel a pending registrant change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ CLAUDE.md
 AGENT.md
 own
 AGENT.md
+/docs/
 

--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,4 @@ AGENT.md
 own
 AGENT.md
 /docs/
-
+.repowise

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+10.08.2026
+* Registrars can now cancel a pending registrant change https://github.com/internetee/registry/issues/2939
+
 23.07.2026
 * Operations with pending status now return result code 1001 in REPP https://github.com/internetee/registry/issues/2940
 * Fixed case sensitivity issue for REPP requests https://github.com/internetee/registry/issues/2943

--- a/app/controllers/epp/domains_controller.rb
+++ b/app/controllers/epp/domains_controller.rb
@@ -9,6 +9,12 @@ module Epp
     THROTTLED_ACTIONS = %i[info create check renew update transfer delete].freeze
     include Shunter::Integration::Throttle
 
+    # Everything Deserializers::Xml::DomainUpdate can emit besides the registrant itself.
+    # :domain and :registrar_id are always present, :legal_document may be mandatory for
+    # the registrar even when cancelling.
+    UPDATE_KEYS_BESIDES_REGISTRANT = %i[contacts nameservers dns_keys statuses transfer_code
+                                        reserved_pw].freeze
+
     def info
       authorize! :info, @domain
 
@@ -47,6 +53,9 @@ module Epp
       registrar_id = current_user.registrar.id
       update_params = ::Deserializers::Xml::DomainUpdate.new(params[:parsed_frame],
                                                              registrar_id).call
+
+      return cancel_pending_update if cancels_pending_update?(update_params)
+
       action = Actions::DomainUpdate.new(@domain, update_params, false)
       unless action.call
         handle_errors(@domain)
@@ -133,6 +142,33 @@ module Epp
     end
 
     private
+
+    # EPP has no command to manipulate pending operations (RFC 3731 covers transfer only),
+    # so a domain:update requesting the registrant the domain already has is treated as a
+    # request to cancel the pending registrant change. Same idea as domain:renew cancelling
+    # pendingDelete in Epp::Domain#renew.
+    def cancels_pending_update?(update_params)
+      return false unless @domain.pending_update?
+      return false if update_params[:registrant].blank?
+
+      requested = Registrant.find_by(code: update_params[:registrant][:code])
+      return false unless requested&.id == @domain.registrant_id
+
+      (update_params.keys & UPDATE_KEYS_BESIDES_REGISTRANT).empty?
+    end
+
+    def cancel_pending_update
+      result = ::Domains::CancelPendingUpdate.run(domain: @domain,
+                                                  initiator: current_user.username)
+      unless result.valid?
+        @domain.add_epp_error('2304', 'status', DomainStatus::PENDING_UPDATE,
+                              result.errors.full_messages.join(', '))
+        handle_errors(@domain)
+        return
+      end
+
+      render_epp_response('/epp/domains/success')
+    end
 
     def validate_info
       @prefix = 'info > info >'

--- a/app/controllers/repp/v1/domains/pending_updates_controller.rb
+++ b/app/controllers/repp/v1/domains/pending_updates_controller.rb
@@ -1,0 +1,29 @@
+module Repp
+  module V1
+    module Domains
+      class PendingUpdatesController < BaseController
+        before_action :set_domain
+
+        THROTTLED_ACTIONS = %i[destroy].freeze
+        include Shunter::Integration::Throttle
+
+        api :DELETE, '/repp/v1/domains/:domain_name/pending_update'
+        param :domain_name, String, desc: 'Domain name'
+        desc 'Cancel a pending registrant change of a specific domain'
+        def destroy
+          authorize!(:update, @domain)
+
+          result = ::Domains::CancelPendingUpdate.run(domain: @domain,
+                                                      initiator: current_user.username)
+          unless result.valid?
+            @domain.add_epp_error('2304', 'status', DomainStatus::PENDING_UPDATE,
+                                  result.errors.full_messages.join(', '))
+            return handle_errors(@domain)
+          end
+
+          render_success(data: { domain: { name: @domain.name } })
+        end
+      end
+    end
+  end
+end

--- a/app/interactions/domains/cancel_pending_update.rb
+++ b/app/interactions/domains/cancel_pending_update.rb
@@ -1,0 +1,52 @@
+module Domains
+  class CancelPendingUpdate < ActiveInteraction::Base
+    object :domain,
+           class: Domain,
+           description: 'Domain with a pending registrant change'
+    string :initiator,
+           default: nil
+
+    validate :domain_has_pending_update
+
+    def execute
+      ::PaperTrail.request.whodunnit = "interaction - #{self.class.name} - cancelled by"\
+        " #{initiator}"
+
+      ActiveRecord::Base.transaction do
+        notify_registrants
+        clean_pendings!
+      end
+
+      UpdateWhoisRecordJob.perform_later(domain.name, 'domain')
+    end
+
+    private
+
+    def domain_has_pending_update
+      return if domain&.pending_update?
+
+      errors.add(:domain, I18n.t(:object_status_prohibits_operation))
+    end
+
+    # Both parties already got a confirmation link that is about to become invalid,
+    # so they are notified before the verification data is wiped.
+    def notify_registrants
+      RegistrantChangeMailer.cancelled(domain: domain,
+                                       registrar: domain.registrar,
+                                       registrant: domain.registrant,
+                                       send_to: [domain.new_registrant_email,
+                                                 domain.registrant.email]).deliver_later
+    end
+
+    def clean_pendings!
+      domain.is_admin = true
+      # Has to happen before save, otherwise before_update reinstates pendingUpdate
+      domain.registrant_verification_token = nil
+      domain.registrant_verification_asked_at = nil
+      domain.pending_json = {}
+      domain.statuses.delete(DomainStatus::PENDING_UPDATE)
+      domain.status_notes[DomainStatus::PENDING_UPDATE] = ''
+      domain.save!
+    end
+  end
+end

--- a/app/interactions/domains/update_confirm/process_action.rb
+++ b/app/interactions/domains/update_confirm/process_action.rb
@@ -2,6 +2,10 @@ module Domains
   module UpdateConfirm
     class ProcessAction < Base
       def execute
+        # The registrant decision arrives asynchronously, so the pending update may already
+        # be gone by now - cancelled by the registrar or cleaned up by the expiry cron.
+        return unless domain.pending_update?
+
         ::PaperTrail.request.whodunnit = "interaction - #{self.class.name} - #{action} by"\
           " #{initiator}"
 

--- a/app/mailers/registrant_change_mailer.rb
+++ b/app/mailers/registrant_change_mailer.rb
@@ -38,6 +38,15 @@ class RegistrantChangeMailer < ApplicationMailer
     mail(to: domain.new_registrant_email, subject: subject)
   end
 
+  def cancelled(domain:, registrar:, registrant:, send_to:)
+    @domain = DomainPresenter.new(domain: domain, view: view_context)
+    @registrar = RegistrarPresenter.new(registrar: registrar, view: view_context)
+    @registrant = RegistrantPresenter.new(registrant: registrant, view: view_context)
+
+    subject = default_i18n_subject(domain_name: domain.name)
+    mail(to: send_to, subject: subject)
+  end
+
   def expired(domain:, registrar:, registrant:, send_to:)
     @domain = DomainPresenter.new(domain: domain, view: view_context)
     @registrar = RegistrarPresenter.new(registrar: registrar, view: view_context)

--- a/app/views/mailers/registrant_change_mailer/cancelled.html.erb
+++ b/app/views/mailers/registrant_change_mailer/cancelled.html.erb
@@ -1,0 +1,18 @@
+Tere
+<br><br>
+Registripidaja tühistas domeeni <%= @domain.name %> registreerija vahetuse taotluse. Varem saadetud kinnituslink ei kehti enam.
+<br><br>
+Küsimuste korral palun võtke ühendust oma registripidajaga:
+
+<%= render 'mailers/shared/registrar/registrar.et.html', registrar: @registrar %>
+<%= render 'mailers/shared/signatures/signature.et.html' %>
+<hr>
+<br><br>
+Hi,
+<br><br>
+The registrar has cancelled the registrant change request for the domain <%= @domain.name %>. The confirmation link sent earlier is no longer valid.
+<br><br>
+Please contact your registrar if you have any questions:
+
+<%= render 'mailers/shared/registrar/registrar.en.html', registrar: @registrar %>
+<%= render 'mailers/shared/signatures/signature.en.html' %>

--- a/app/views/mailers/registrant_change_mailer/cancelled.text.erb
+++ b/app/views/mailers/registrant_change_mailer/cancelled.text.erb
@@ -1,0 +1,20 @@
+Tere
+
+Registripidaja tühistas domeeni <%= @domain.name %> registreerija vahetuse taotluse. Varem saadetud kinnituslink ei kehti enam.
+
+Küsimuste korral palun võtke ühendust oma registripidajaga:
+
+<%= render 'mailers/shared/registrar/registrar.et.text', registrar: @registrar %>
+<%= render 'mailers/shared/signatures/signature.et.text' %>
+
+--------------------------------------
+
+Hi,
+
+The registrar has cancelled the registrant change request for the domain <%= @domain.name %>. The confirmation link sent earlier is no longer valid.
+
+Please contact your registrar if you have any questions:
+
+<%= render 'mailers/shared/registrar/registrar.en.text', registrar: @registrar %>
+
+<%= render 'mailers/shared/signatures/signature.en.text' %>

--- a/config/locales/mailers/registrant_change.en.yml
+++ b/config/locales/mailers/registrant_change.en.yml
@@ -20,3 +20,7 @@ en:
       subject: >-
         Domeeni %{domain_name} registreerija vahetuse taotlus on tühistatud
         / %{domain_name} registrant change cancelled
+    cancelled:
+      subject: >-
+        Registripidaja tühistas domeeni %{domain_name} registreerija vahetuse taotluse
+        / %{domain_name} registrant change request was cancelled by the registrar

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -167,6 +167,7 @@ Rails.application.routes.draw do
         resources :renew, only: %i[create], constraints: { id: /.*/ }, controller: 'domains/renews'
         resources :transfer, only: %i[create], constraints: { id: /.*/ }, controller: 'domains/transfers'
         resources :statuses, only: %i[update destroy], constraints: { id: /.*/ }, controller: 'domains/statuses'
+        resource :pending_update, only: %i[destroy], controller: 'domains/pending_updates'
         match 'dnssec', to: 'domains/dnssec#destroy', via: 'delete', defaults: { id: nil }
         match 'contacts', to: 'domains/contacts#destroy', via: 'delete', defaults: { id: nil }
         collection do

--- a/test/integration/epp/domain/update/cancel_pending_test.rb
+++ b/test/integration/epp/domain/update/cancel_pending_test.rb
@@ -1,0 +1,129 @@
+require 'test_helper'
+
+class EppDomainUpdateCancelPendingTest < EppTestCase
+  include ActionMailer::TestHelper
+  include ActiveJob::TestHelper
+
+  setup do
+    @domain = domains(:shop)
+    @original_registrant_change_verification =
+      Setting.request_confirmation_on_registrant_change_enabled
+    Setting.request_confirmation_on_registrant_change_enabled = true
+    ActionMailer::Base.deliveries.clear
+
+    adapter = ENV['shunter_default_adapter'].constantize.new
+    adapter&.clear!
+  end
+
+  teardown do
+    Setting.request_confirmation_on_registrant_change_enabled =
+      @original_registrant_change_verification
+  end
+
+  def test_cancels_pending_update_when_current_registrant_is_requested_again
+    request_registrant_change
+    old_registrant = @domain.registrant
+
+    post_domain_update(old_registrant)
+
+    assert_epp_response :completed_successfully
+    assert_equal old_registrant, @domain.registrant
+    assert_not_includes @domain.statuses, DomainStatus::PENDING_UPDATE
+    assert_empty @domain.pending_json
+    assert_not @domain.registrant_verification_asked?
+  end
+
+  def test_notifies_both_registrants_when_pending_update_is_cancelled
+    request_registrant_change
+    new_registrant_email = @domain.new_registrant_email
+    registrant_email = @domain.registrant.email
+    ActionMailer::Base.deliveries.clear
+
+    perform_enqueued_jobs { post_domain_update(@domain.registrant) }
+
+    email = ActionMailer::Base.deliveries.last
+    assert_includes email.to, new_registrant_email
+    assert_includes email.to, registrant_email
+  end
+
+  def test_rejects_update_of_pending_domain_when_another_registrant_is_requested
+    request_registrant_change
+    old_registrant = @domain.registrant
+
+    post_domain_update(contacts(:jack))
+
+    assert_epp_response :object_status_prohibits_operation
+    assert_equal old_registrant, @domain.registrant
+    assert_includes @domain.statuses, DomainStatus::PENDING_UPDATE
+  end
+
+  def test_does_not_cancel_pending_update_when_other_changes_are_requested
+    request_registrant_change
+    old_transfer_code = @domain.transfer_code
+
+    post_domain_update(@domain.registrant, transfer_code: 'new-transfer-code')
+
+    assert_epp_response :object_status_prohibits_operation
+    assert_equal old_transfer_code, @domain.transfer_code
+    assert_includes @domain.statuses, DomainStatus::PENDING_UPDATE
+  end
+
+  def test_keeps_regular_update_intact_when_domain_has_no_pending_update
+    assert_not_includes @domain.statuses, DomainStatus::PENDING_UPDATE
+
+    post_domain_update(@domain.registrant)
+
+    assert_epp_response :completed_successfully
+    assert_not_includes @domain.statuses, DomainStatus::PENDING_UPDATE
+  end
+
+  private
+
+  def request_registrant_change
+    new_registrant = contacts(:william)
+    assert_not_equal new_registrant, @domain.registrant
+
+    post_domain_update(new_registrant)
+
+    assert_epp_response :completed_successfully_action_pending
+    assert_includes @domain.statuses, DomainStatus::PENDING_UPDATE
+  end
+
+  def post_domain_update(registrant, transfer_code: nil)
+    post epp_update_path,
+         params: { frame: registrant_change_xml(registrant, transfer_code: transfer_code) },
+         headers: { 'HTTP_COOKIE' => 'session=api_bestnames' }
+
+    # assert_epp_response memoizes the parsed response, reset it between requests
+    @epp_response = nil
+    @domain.reload
+  end
+
+  def registrant_change_xml(registrant, transfer_code: nil)
+    auth_info = if transfer_code
+                  "<domain:authInfo><domain:pw>#{transfer_code}</domain:pw></domain:authInfo>"
+                end
+
+    <<-XML
+      <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+      <epp xmlns="#{Xsd::Schema.filename(for_prefix: 'epp-ee', for_version: '1.0')}">
+        <command>
+          <update>
+            <domain:update xmlns:domain="#{Xsd::Schema.filename(for_prefix: 'domain-ee', for_version: '1.2')}">
+              <domain:name>#{@domain.name}</domain:name>
+              <domain:chg>
+                <domain:registrant verified="no">#{registrant.code}</domain:registrant>
+                #{auth_info}
+              </domain:chg>
+            </domain:update>
+          </update>
+          <extension>
+            <eis:extdata xmlns:eis="#{Xsd::Schema.filename(for_prefix: 'eis', for_version: '1.0')}">
+              <eis:legalDocument type="pdf">#{'test' * 2000}</eis:legalDocument>
+            </eis:extdata>
+          </extension>
+        </command>
+      </epp>
+    XML
+  end
+end

--- a/test/integration/repp/v1/domains/cancel_pending_update_test.rb
+++ b/test/integration/repp/v1/domains/cancel_pending_update_test.rb
@@ -1,0 +1,94 @@
+require 'test_helper'
+
+class ReppV1DomainsCancelPendingUpdateTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:api_bestnames)
+    @domain = domains(:shop)
+    token = Base64.encode64("#{@user.username}:#{@user.plain_text_password}")
+    @auth_headers = { 'Authorization' => "Basic #{token}" }
+    Setting.request_confirmation_on_registrant_change_enabled = true
+  end
+
+  def test_cancels_pending_registrant_change
+    request_registrant_change
+
+    json = cancel_pending_update
+
+    assert_response :ok
+    assert_equal 1000, json[:code]
+    assert_equal @domain.name, json[:data][:domain][:name]
+    refute_includes @domain.statuses, DomainStatus::PENDING_UPDATE
+    assert_empty @domain.pending_json
+    assert_nil @domain.registrant_verification_token
+    assert_nil @domain.registrant_verification_asked_at
+  end
+
+  def test_keeps_current_registrant_on_cancel
+    old_registrant = @domain.registrant
+    request_registrant_change
+
+    cancel_pending_update
+
+    assert_equal old_registrant, @domain.registrant
+  end
+
+  def test_notifies_both_registrants_on_cancel
+    request_registrant_change
+    new_registrant_email = @domain.new_registrant_email
+    registrant_email = @domain.registrant.email
+    ActionMailer::Base.deliveries.clear
+
+    perform_enqueued_jobs { cancel_pending_update }
+
+    email = ActionMailer::Base.deliveries.last
+    assert_includes email.to, new_registrant_email
+    assert_includes email.to, registrant_email
+  end
+
+  def test_returns_error_when_domain_has_no_pending_update
+    refute_includes @domain.statuses, DomainStatus::PENDING_UPDATE
+
+    json = cancel_pending_update
+
+    assert_response :bad_request
+    assert_equal 2304, json[:code]
+  end
+
+  def test_does_not_cancel_pending_update_of_another_registrar
+    request_registrant_change
+    other_user = users(:api_goodnames)
+    token = Base64.encode64("#{other_user.username}:#{other_user.plain_text_password}")
+    @auth_headers = { 'Authorization' => "Basic #{token}" }
+
+    json = cancel_pending_update
+
+    assert_response :not_found
+    assert_equal 2303, json[:code]
+    assert_includes @domain.statuses, DomainStatus::PENDING_UPDATE
+  end
+
+  private
+
+  def request_registrant_change
+    new_registrant = contacts(:william)
+    refute_equal new_registrant, @domain.registrant
+
+    put "/repp/v1/domains/#{@domain.name}",
+        headers: json_headers,
+        params: { domain: { registrant: { code: new_registrant.code } } }.to_json
+
+    @domain.reload
+    assert_includes @domain.statuses, DomainStatus::PENDING_UPDATE
+  end
+
+  def cancel_pending_update
+    delete "/repp/v1/domains/#{@domain.name}/pending_update", headers: json_headers
+
+    @domain.reload
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def json_headers
+    @auth_headers.merge('Content-Type' => 'application/json')
+  end
+end

--- a/test/interactions/domains/cancel_pending_update_test.rb
+++ b/test/interactions/domains/cancel_pending_update_test.rb
@@ -1,0 +1,80 @@
+require 'test_helper'
+
+module Domains
+  class CancelPendingUpdateTest < ActiveSupport::TestCase
+    include ActionMailer::TestHelper
+    include ActiveJob::TestHelper
+
+    setup do
+      @domain = domains(:shop)
+      @new_registrant = contacts(:william)
+      @domain.update!(registrant_verification_asked_at: Time.zone.now,
+                      registrant_verification_token: 'test')
+      @domain.pending_json = { 'new_registrant_id' => @new_registrant.id,
+                               'new_registrant_email' => @new_registrant.email,
+                               'new_registrant_name' => @new_registrant.name }
+      @domain.statuses = [DomainStatus::PENDING_UPDATE]
+      @domain.save(validate: false)
+      ActionMailer::Base.deliveries.clear
+    end
+
+    def test_clears_pending_update_data
+      CancelPendingUpdate.run!(domain: @domain, initiator: 'test')
+      @domain.reload
+
+      assert_not_includes @domain.statuses, DomainStatus::PENDING_UPDATE
+      assert_empty @domain.pending_json
+      assert_nil @domain.registrant_verification_token
+      assert_nil @domain.registrant_verification_asked_at
+      assert_equal '', @domain.status_notes[DomainStatus::PENDING_UPDATE]
+    end
+
+    def test_keeps_registrant_untouched
+      old_registrant = @domain.registrant
+
+      CancelPendingUpdate.run!(domain: @domain, initiator: 'test')
+      @domain.reload
+
+      assert_equal old_registrant, @domain.registrant
+    end
+
+    def test_notifies_both_registrants
+      registrant_email = @domain.registrant.email
+
+      perform_enqueued_jobs do
+        CancelPendingUpdate.run!(domain: @domain, initiator: 'test')
+      end
+
+      email = ActionMailer::Base.deliveries.last
+      assert_includes email.to, @new_registrant.email
+      assert_includes email.to, registrant_email
+    end
+
+    def test_updates_whois_record
+      assert_enqueued_with(job: UpdateWhoisRecordJob, args: [@domain.name, 'domain']) do
+        CancelPendingUpdate.run!(domain: @domain, initiator: 'test')
+      end
+    end
+
+    def test_fails_when_domain_has_no_pending_update
+      @domain.statuses = []
+      @domain.save(validate: false)
+
+      result = CancelPendingUpdate.run(domain: @domain, initiator: 'test')
+
+      assert_not result.valid?
+      assert_no_enqueued_emails
+    end
+
+    def test_does_not_touch_other_statuses
+      @domain.statuses = [DomainStatus::PENDING_UPDATE, DomainStatus::CLIENT_HOLD]
+      @domain.save(validate: false)
+
+      CancelPendingUpdate.run!(domain: @domain, initiator: 'test')
+      @domain.reload
+
+      assert_includes @domain.statuses, DomainStatus::CLIENT_HOLD
+      assert_not_includes @domain.statuses, DomainStatus::PENDING_UPDATE
+    end
+  end
+end

--- a/test/jobs/domain_update_confirm_job_test.rb
+++ b/test/jobs/domain_update_confirm_job_test.rb
@@ -36,7 +36,23 @@ class DomainUpdateConfirmJobTest < ActiveSupport::TestCase
     assert_equal(@domain.registrar.notifications.last.text, "Domain #{@domain.name} has been unlocked by registrant")
   end
 
+  # The registrant decision may reach us after the registrar has already cancelled
+  # the pending update, or after the expiry cron has cleaned it up.
+  def test_skips_confirmation_when_pending_update_is_already_gone
+    set_pending_update
+    old_registrant_code = @domain.registrant.code
+    @domain.update!(statuses: [DomainStatus::OK])
+
+    assert_no_difference '@domain.registrar.notifications.count' do
+      DomainUpdateConfirmJob.perform_now(@domain.id, RegistrantVerification::CONFIRMED)
+    end
+    @domain.reload
+
+    assert_equal old_registrant_code, @domain.registrant.code
+  end
+
   def test_rejected_registrant_verification_notifies_registrar
+    set_pending_update
     DomainUpdateConfirmJob.perform_now(@domain.id, RegistrantVerification::REJECTED)
 
     last_registrar_notification = @domain.registrar.notifications.last
@@ -45,6 +61,7 @@ class DomainUpdateConfirmJobTest < ActiveSupport::TestCase
   end
 
   def test_accepted_registrant_verification_notifies_registrar
+    set_pending_update
     DomainUpdateConfirmJob.perform_now(@domain.id, RegistrantVerification::CONFIRMED)
 
     last_registrar_notification = @domain.registrar.notifications.last
@@ -61,6 +78,7 @@ class DomainUpdateConfirmJobTest < ActiveSupport::TestCase
 
     @domain.pending_json['frame'] = parsed_frame
     @domain.update(pending_json: @domain.pending_json)
+    set_pending_update
 
     @domain.reload
     DomainUpdateConfirmJob.perform_now(@domain.id, RegistrantVerification::CONFIRMED)
@@ -79,6 +97,7 @@ class DomainUpdateConfirmJobTest < ActiveSupport::TestCase
 
     @domain.pending_json['frame'] = parsed_frame
     @domain.update(pending_json: @domain.pending_json)
+    set_pending_update
 
     DomainUpdateConfirmJob.perform_now(@domain.id, RegistrantVerification::REJECTED)
     @domain.reload
@@ -96,7 +115,8 @@ class DomainUpdateConfirmJobTest < ActiveSupport::TestCase
 
     @domain.pending_json['frame'] = parsed_frame
     @domain.update(pending_json: @domain.pending_json)
-    @domain.update(statuses: [DomainStatus::DELETE_CANDIDATE, DomainStatus::DISPUTED])
+    @domain.update(statuses: [DomainStatus::DELETE_CANDIDATE, DomainStatus::DISPUTED,
+                              DomainStatus::PENDING_UPDATE])
 
     DomainUpdateConfirmJob.perform_now(@domain.id, RegistrantVerification::REJECTED)
     @domain.reload
@@ -116,7 +136,8 @@ class DomainUpdateConfirmJobTest < ActiveSupport::TestCase
 
     @domain.pending_json['frame'] = parsed_frame
     @domain.update(pending_json: @domain.pending_json)
-    @domain.update(statuses: [DomainStatus::DELETE_CANDIDATE, DomainStatus::DISPUTED])
+    @domain.update(statuses: [DomainStatus::DELETE_CANDIDATE, DomainStatus::DISPUTED,
+                              DomainStatus::PENDING_UPDATE])
 
     DomainUpdateConfirmJob.perform_now(@domain.id, RegistrantVerification::CONFIRMED)
     @domain.reload
@@ -137,7 +158,8 @@ class DomainUpdateConfirmJobTest < ActiveSupport::TestCase
     @domain.pending_json['frame'] = parsed_frame
     @domain.pending_json['current_user_id'] = { key: 'some_value'}
     @domain.update(pending_json: @domain.pending_json)
-    @domain.update(statuses: [DomainStatus::DELETE_CANDIDATE, DomainStatus::DISPUTED])
+    @domain.update(statuses: [DomainStatus::DELETE_CANDIDATE, DomainStatus::DISPUTED,
+                              DomainStatus::PENDING_UPDATE])
 
     assert_nothing_raised do
       DomainUpdateConfirmJob.perform_now(@domain.id, RegistrantVerification::CONFIRMED)
@@ -190,5 +212,13 @@ class DomainUpdateConfirmJobTest < ActiveSupport::TestCase
     assert_not @domain.statuses.include? DomainStatus::PENDING_DELETE
     assert_not @domain.statuses.include? DomainStatus::PENDING_UPDATE
     assert @domain.statuses.include? DomainStatus::OK
+  end
+
+  private
+
+  def set_pending_update
+    @domain.statuses = [DomainStatus::PENDING_UPDATE]
+    @domain.save(validate: false)
+    @domain.reload
   end
 end


### PR DESCRIPTION
Closes #2939

## Problem

Once a registrant change goes pending, the registrar has no way back — either wait 48 hours for the expiry cron, or ask the registry to clear it by hand. `pendingDelete` has an escape hatch (a renew cancels it, `Epp::Domain#renew`), `pendingUpdate` has none.

## Approach

A pending update never touches the domain in the database — `Domain#pending_update!` reloads the record and the requested frame lives in `pending_json` until the registrant confirms. So cancelling is a matter of wiping the pending data; there is nothing to roll back.

`Domains::CancelPendingUpdate` does that and is shared by both interfaces.

### EPP

RFC 3731 defines no way to manipulate pending operations — transform commands MUST be rejected while a `pending*` status is set, with limited exceptions for transfer only, and `op="cancel"` belongs to `<transfer>`. So, as the issue suggests, cancelling is expressed as a new `domain:update`: a request asking for the registrant the domain already has is treated as a cancel. Any other update of a `pendingUpdate` domain still returns `2304`. Same idea as `domain:renew` cancelling `pendingDelete`.

No schema change, and the response reuses the existing `1000` template.

### REPP

`op` is not used anywhere in REPP (transfer is modelled as its own endpoints), so cancelling gets an explicit one:

```
DELETE /repp/v1/domains/:domain_id/pending_update
```

Scoped to the sponsoring registrar via `BaseController#set_domain`. Returns `1000`; `2304` when the domain has no pending update.

Note the asymmetry: `PUT /repp/v1/domains/:id` with the current registrant still returns `2304` — in REPP the explicit `DELETE` is the way.

### Notifications

Both registrants get a `RegistrantChangeMailer#cancelled` mail: the confirmation link they received stops working once the token is cleared. No poll message to the registrar — they initiated the cancel themselves.

### Race between confirm and cancel

The registrant decision arrives through `DomainUpdateConfirmJob`, so it can land after the pending update was already cancelled — or cleaned up by the expiry cron — and replay an empty frame (empty update, a stray "accepted" mail and a "confirmed" poll message). `Domains::UpdateConfirm::ProcessAction` now bails out when the domain is no longer pending. This closes the pre-existing cron-vs-confirm variant of the same race too.

## Tests

5 REPP + 5 EPP + 6 interaction + 1 for the race guard. Full run of `test/integration/epp/domain/update/`, `test/integration/repp/v1/domains/`, `test/interactions/domains/`, `test/models/domain/`, `test/jobs/`, admin and registrant-API confirm paths: 0 failures.

Several tests in `domain_update_confirm_job_test.rb` set the domain up without `pendingUpdate` — impossible in any real flow, since both `registrant_update_confirmable?` and the admin controller require it. Three of them broke on the new guard and four were passing vacuously; they now reflect the actual state.

## For review

- With `legaldoc_mandatory`, a registrar has to attach a legalDocument to cancel as well — `validate_update` requires one whenever `chg > registrant` is present. Not special-cased on purpose; say if it should be.
- Rubocop was not run locally (the gem is not installed in the container and `.rubocop.yml` is gitignored) — leaving it to CI.
- The registrar portal button is a separate PR in `registrar_center2`, against this endpoint.