### PR TITLE
Sort admin registrar dropdowns alphabetically.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -107,4 +107,8 @@ module ApplicationHelper
     end
     result
   end
+
+  def registrar_options(value: :id)
+    Registrar.ordered.map { |registrar| [registrar.name, registrar.public_send(value)] }
+  end
 end

--- a/app/views/admin/account_activities/_search_form.html.erb
+++ b/app/views/admin/account_activities/_search_form.html.erb
@@ -5,7 +5,7 @@
                 <div class="col-md-12">
                     <div class="form-group">
                         <%= f.label t(:registrar_name) %>
-                        <%= f.select :account_registrar_id_in, Registrar.all.map { |x| [x, x.id] }, {}, class: 'form-control js-combobox', placeholder: t(:choose), multiple: true %>
+                        <%= f.select :account_registrar_id_in, registrar_options, {}, class: 'form-control js-combobox', placeholder: t(:choose), multiple: true %>
                     </div>
                 </div>
             </div>

--- a/app/views/admin/accounts/_search_form.html.erb
+++ b/app/views/admin/accounts/_search_form.html.erb
@@ -5,7 +5,7 @@
                 <div class="col-md-3">
                     <div class="form-group">
                         <%= f.label t(:registrar_name) %>
-                        <%= f.select :registrar_id_in, Registrar.all.map { |x| [x, x.id] }, {}, class: 'form-control js-combobox', placeholder: t(:choose), multiple: true %>
+                        <%= f.select :registrar_id_in, registrar_options, {}, class: 'form-control js-combobox', placeholder: t(:choose), multiple: true %>
                     </div>
                 </div>
                 <div class="col-md-3">

--- a/app/views/admin/contacts/index.haml
+++ b/app/views/admin/contacts/index.haml
@@ -37,7 +37,7 @@
         .col-md-3
           .form-group
             = f.label t(:registrar_name)
-            = f.select :registrar_id_eq, Registrar.all.map { |x| [x, x.id] }, { include_blank: true }, class: 'form-control', placeholder: t(:choose)
+            = f.select :registrar_id_eq, registrar_options, { include_blank: true }, class: 'form-control', placeholder: t(:choose)
         .col-md-3
           .form-group
             = f.label t(:created_at_from)

--- a/app/views/admin/domain_versions/archive.haml
+++ b/app/views/admin/domain_versions/archive.haml
@@ -15,7 +15,7 @@
         .col-md-3
           .form-group
             = label_tag t(:registrar_name)
-            = select_tag '[q][registrar]', options_for_select(Registrar.all.map { |r| [r.name] }, selected: params[:q][:registrar]), { include_blank: true, class: 'form-control', placeholder: t('.registrant')}
+            = select_tag '[q][registrar]', options_for_select(registrar_options(value: :name), selected: params[:q][:registrar]), { include_blank: true, class: 'form-control', placeholder: t('.registrant')}
         .col-md-3
           .form-group
             = label_tag :action

--- a/app/views/admin/domains/_search_form.html.erb
+++ b/app/views/admin/domains/_search_form.html.erb
@@ -29,7 +29,7 @@
   <div class="col-md-5">
     <div class="form-group">
       <%= f.label :registrar_name, for: nil %>
-      <%= select_tag 'q[registrar_id_eq]', options_for_select(Registrar.all.map { |x| [x, x.id] }, params[:q][:registrar_id_eq]), { include_blank:true, class: 'form-control' } %>
+      <%= select_tag 'q[registrar_id_eq]', options_for_select(registrar_options, params[:q][:registrar_id_eq]), { include_blank:true, class: 'form-control' } %>
     </div>
   </div>
   <div class="col-md-3">

--- a/app/views/admin/epp_logs/index.haml
+++ b/app/views/admin/epp_logs/index.haml
@@ -27,7 +27,7 @@
         .col-md-3
           .form-group
             = f.label :registrar
-            = f.select :api_user_registrar_matches, Registrar.all.map { |x| [x, x.name] }, { include_blank: true }, class: 'form-control', placeholder: t(:choose)
+            = f.select :api_user_registrar_matches, registrar_options(value: :name), { include_blank: true }, class: 'form-control', placeholder: t(:choose)
         .col-md-3
           .form-group
             = f.label t(:created_after)

--- a/app/views/admin/invoices/new.haml
+++ b/app/views/admin/invoices/new.haml
@@ -12,7 +12,7 @@
         .col-md-4.control-label
           = f.label :registrar_id, class: 'required'
         .col-md-8
-          = select_tag 'deposit[registrar_id]', options_for_select(Registrar.all.map { |r| [r.name, r.id] }), { prompt: t(:choose), required: true, class: 'form-control js-combobox' }
+          = select_tag 'deposit[registrar_id]', options_for_select(registrar_options), { prompt: t(:choose), required: true, class: 'form-control js-combobox' }
 
       .form-group
         .col-md-4.control-label

--- a/app/views/admin/invoices/partials/_search_form.html.erb
+++ b/app/views/admin/invoices/partials/_search_form.html.erb
@@ -36,7 +36,7 @@
                 <div class="col-md-6">
                     <div class="form-group">
                         <%= f.label "Registrar" %>
-                        <%= f.select :buyer_id_in, Registrar.all.map { |x| [x, x.id] }, {}, class: 'form-control js-combobox', placeholder: t(:choose), multiple: true %>
+                        <%= f.select :buyer_id_in, registrar_options, {}, class: 'form-control js-combobox', placeholder: t(:choose), multiple: true %>
                     </div>
                 </div>
 

--- a/app/views/admin/repp_logs/index.haml
+++ b/app/views/admin/repp_logs/index.haml
@@ -25,7 +25,7 @@
         .col-md-3
           .form-group
             = f.label :registrar
-            = f.select :api_user_registrar_matches, Registrar.all.map { |x| [x, x.name] }, { include_blank: true }, class: 'form-control', placeholder: t(:choose)
+            = f.select :api_user_registrar_matches, registrar_options(value: :name), { include_blank: true }, class: 'form-control', placeholder: t(:choose)
         .col-md-3
           .form-group
             = f.label t(:created_after)

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -11,4 +11,16 @@ class ApplicationHelperTest < ActionView::TestCase
       ApplicationController.helpers.updator_link(model)
     end
   end
+
+  def test_registrar_options_are_sorted_by_name
+    registrars(:bestnames).update_columns(name: 'Zulu Names')
+    registrars(:goodnames).update_columns(name: 'Alpha Names')
+
+    options = registrar_options
+    names = options.map(&:first).reject(&:blank?)
+
+    assert_equal names.sort, names
+    assert_equal 'Alpha Names', names.first
+    assert_equal registrars(:goodnames).id, options.find { |name, _id| name == 'Alpha Names' }.last
+  end
 end

--- a/test/integration/admin_area/registrar_select_options_test.rb
+++ b/test/integration/admin_area/registrar_select_options_test.rb
@@ -1,0 +1,77 @@
+require 'test_helper'
+
+class AdminAreaRegistrarSelectOptionsTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    sign_in users(:admin)
+    registrars(:bestnames).update_columns(name: 'Zulu Names')
+    registrars(:goodnames).update_columns(name: 'Alpha Names')
+  end
+
+  def test_admin_domains_registrar_dropdown_is_sorted_alphabetically
+    get admin_domains_path
+    assert_response :success
+    assert_registrar_options_sorted '#q_registrar_id_eq'
+  end
+
+  def test_admin_contacts_registrar_dropdown_is_sorted_alphabetically
+    get admin_contacts_path
+    assert_response :success
+    assert_registrar_options_sorted '#q_registrar_id_eq'
+  end
+
+  def test_admin_invoices_registrar_dropdown_is_sorted_alphabetically
+    get admin_invoices_path
+    assert_response :success
+    assert_registrar_options_sorted '#q_buyer_id_in'
+  end
+
+  def test_admin_new_invoice_registrar_dropdown_is_sorted_alphabetically
+    get new_admin_invoice_path
+    assert_response :success
+    assert_registrar_options_sorted '#deposit_registrar_id'
+  end
+
+  def test_admin_accounts_registrar_dropdown_is_sorted_alphabetically
+    get admin_accounts_path
+    assert_response :success
+    assert_registrar_options_sorted '#q_registrar_id_in'
+  end
+
+  def test_admin_account_activities_registrar_dropdown_is_sorted_alphabetically
+    get admin_account_activities_path, params: { created_after: 'today' }
+    assert_response :success
+    assert_registrar_options_sorted '#q_account_registrar_id_in'
+  end
+
+  def test_admin_domain_versions_registrar_dropdown_is_sorted_alphabetically
+    get admin_domain_versions_path
+    assert_response :success
+    assert_registrar_options_sorted '#_q_registrar'
+  end
+
+  def test_admin_epp_logs_registrar_dropdown_is_sorted_alphabetically
+    get admin_epp_logs_path
+    assert_response :success
+    assert_registrar_options_sorted '#q_api_user_registrar_matches'
+  end
+
+  def test_admin_repp_logs_registrar_dropdown_is_sorted_alphabetically
+    get admin_repp_logs_path
+    assert_response :success
+    assert_registrar_options_sorted '#q_api_user_registrar_matches'
+  end
+
+  private
+
+  def assert_registrar_options_sorted(select_css)
+    expected = Registrar.ordered.map(&:name).reject(&:blank?)
+    names = css_select("#{select_css} option").map { |option| option.text.strip }
+    registrar_names = names.select { |name| expected.include?(name) }
+
+    assert_equal expected, registrar_names
+    assert_equal 'Alpha Names', registrar_names.first
+    assert_equal 'Zulu Names', registrar_names.last
+  end
+end

--- a/test/integration/admin_area/registrar_select_options_test.rb
+++ b/test/integration/admin_area/registrar_select_options_test.rb
@@ -10,63 +10,52 @@ class AdminAreaRegistrarSelectOptionsTest < ActionDispatch::IntegrationTest
   end
 
   def test_admin_domains_registrar_dropdown_is_sorted_alphabetically
-    get admin_domains_path
-    assert_response :success
-    assert_registrar_options_sorted '#q_registrar_id_eq'
+    assert_registrar_dropdown_sorted admin_domains_path, '#q_registrar_id_eq'
   end
 
   def test_admin_contacts_registrar_dropdown_is_sorted_alphabetically
-    get admin_contacts_path
-    assert_response :success
-    assert_registrar_options_sorted '#q_registrar_id_eq'
+    assert_registrar_dropdown_sorted admin_contacts_path, '#q_registrar_id_eq'
   end
 
   def test_admin_invoices_registrar_dropdown_is_sorted_alphabetically
-    get admin_invoices_path
-    assert_response :success
-    assert_registrar_options_sorted '#q_buyer_id_in'
+    assert_registrar_dropdown_sorted admin_invoices_path, '#q_buyer_id_in'
   end
 
   def test_admin_new_invoice_registrar_dropdown_is_sorted_alphabetically
-    get new_admin_invoice_path
-    assert_response :success
-    assert_registrar_options_sorted '#deposit_registrar_id'
+    assert_registrar_dropdown_sorted new_admin_invoice_path, '#deposit_registrar_id'
   end
 
   def test_admin_accounts_registrar_dropdown_is_sorted_alphabetically
-    get admin_accounts_path
-    assert_response :success
-    assert_registrar_options_sorted '#q_registrar_id_in'
+    assert_registrar_dropdown_sorted admin_accounts_path, '#q_registrar_id_in'
   end
 
   def test_admin_account_activities_registrar_dropdown_is_sorted_alphabetically
-    get admin_account_activities_path, params: { created_after: 'today' }
-    assert_response :success
-    assert_registrar_options_sorted '#q_account_registrar_id_in'
+    assert_registrar_dropdown_sorted(
+      admin_account_activities_path,
+      '#q_account_registrar_id_in',
+      params: { created_after: 'today' }
+    )
   end
 
   def test_admin_domain_versions_registrar_dropdown_is_sorted_alphabetically
-    get admin_domain_versions_path
-    assert_response :success
-    assert_registrar_options_sorted '#_q_registrar'
+    assert_registrar_dropdown_sorted admin_domain_versions_path, '#_q_registrar'
   end
 
   def test_admin_epp_logs_registrar_dropdown_is_sorted_alphabetically
-    get admin_epp_logs_path
-    assert_response :success
-    assert_registrar_options_sorted '#q_api_user_registrar_matches'
+    assert_registrar_dropdown_sorted admin_epp_logs_path, '#q_api_user_registrar_matches'
   end
 
   def test_admin_repp_logs_registrar_dropdown_is_sorted_alphabetically
-    get admin_repp_logs_path
-    assert_response :success
-    assert_registrar_options_sorted '#q_api_user_registrar_matches'
+    assert_registrar_dropdown_sorted admin_repp_logs_path, '#q_api_user_registrar_matches'
   end
 
   private
 
-  def assert_registrar_options_sorted(select_css)
-    expected = Registrar.ordered.map(&:name).reject(&:blank?)
+  def assert_registrar_dropdown_sorted(path, select_css, params: {})
+    get path, params: params
+    assert_response :success
+
+    expected = Registrar.ordered.filter_map { |registrar| registrar.name.presence }
     names = css_select("#{select_css} option").map { |option| option.text.strip }
     registrar_names = names.select { |name| expected.include?(name) }
 

--- a/test/models/registrar_test.rb
+++ b/test/models/registrar_test.rb
@@ -310,6 +310,17 @@ class RegistrarTest < ActiveJob::TestCase
     Setting.legal_document_is_mandatory = old_value
   end
 
+  def test_ordered_returns_registrars_sorted_by_name
+    registrars(:bestnames).update_columns(name: 'Zulu Names')
+    registrars(:goodnames).update_columns(name: 'Alpha Names')
+
+    ordered_names = Registrar.ordered.pluck(:name).reject(&:blank?)
+
+    assert_equal ordered_names.sort, ordered_names
+    assert_equal 'Alpha Names', ordered_names.first
+    assert_equal 'Zulu Names', ordered_names.last
+  end
+
   private
 
   def valid_registrar


### PR DESCRIPTION
Setting registrar name list in alphabetical order in every form 'Registrar' selection under admin area.
